### PR TITLE
Access g_form in DevTools Console for Agent Workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true
+}

--- a/Client Scripts/Access g_form in AW/readme.md
+++ b/Client Scripts/Access g_form in AW/readme.md
@@ -1,0 +1,7 @@
+# Access g_form instance inside Agent Workspace from DevTools Console
+When developing forms in ServiceNow it can be useful to try stuff out directly in the DevTools Console.
+In UI16 this was pretty straightforward because g_form was available globally, Agent Workspace makes this a little bit more complicated.
+So this script provides access to the g_form object of the currently active tab in a Workspace.
+
+Just copy the Script in the DevTools Console and run `var g_form = getGlideFormAW()` 
+now you should be able to do stuff like `g_form.setValue("short_description", "Lorem ipsum")`

--- a/Client Scripts/Access g_form in AW/script.js
+++ b/Client Scripts/Access g_form in AW/script.js
@@ -1,0 +1,23 @@
+function getGlideFormAW() {
+    document.getElementsByTagName("sn-workspace-content")[0].shadowRoot.querySelectorAll("now-record-form-connected")[0]
+
+    var firstContentChild = document.getElementsByTagName("sn-workspace-content")[0].shadowRoot
+        .querySelectorAll(".chrome-tab-panel.is-active")[0].firstChild;
+
+    var snWorkspaceFormEl;
+    if (firstContentChild.tagName == "NOW-RECORD-FORM-CONNECTED") {
+        snWorkspaceFormEl = firstContentChild.shadowRoot.querySelectorAll(".sn-workspace-form")[0];
+    } else {
+        snWorkspaceFormEl = firstContentChild.shadowRoot.querySelectorAll("now-record-form-connected")[0]
+            .shadowRoot.querySelectorAll(".sn-workspace-form")[0];
+    }
+    if (!snWorkspaceFormEl) throw "Couldn't find sn-workspace-form";
+
+    var reactInternalInstanceKey = Object.keys(snWorkspaceFormEl).find(function (objKey) {
+        if (objKey.indexOf("__reactInternalInstance$") >= 0) {
+            return true;
+        }
+        return false;
+    });
+    return snWorkspaceFormEl[reactInternalInstanceKey].return.stateNode.props.glideEnvironment._gForm;
+}

--- a/Script Includes/OrderedRecords/readme.md
+++ b/Script Includes/OrderedRecords/readme.md
@@ -1,4 +1,4 @@
-# ListFieldUtil
+# ArtifactRank
 Script Include that helps with getting the next spaced out ordering 
 
 ## Example Script


### PR DESCRIPTION
Added client script which provides a way to access g_form of the current agent workspace tab inside the devtools console.