### PR TITLE
onSubmit Ajax validation with no getXMLWait

### DIFF
--- a/Client Scripts/Sync Ajax with no getXMLWait/readme.md
+++ b/Client Scripts/Sync Ajax with no getXMLWait/readme.md
@@ -1,0 +1,7 @@
+# onSubmit Ajax validation with no getXMLWait
+
+Using getXMLWait() ensures the order of execution, but can cause the application to seem unresponsive, significantly degrading the user experience of any application that uses it.
+
+Also, the getXMLWait method is not available in scoped applications.
+
+This snippet simulates the behavior of the getXMLWait method.

--- a/Client Scripts/Sync Ajax with no getXMLWait/script.js
+++ b/Client Scripts/Sync Ajax with no getXMLWait/script.js
@@ -1,0 +1,19 @@
+function onSubmit() {
+	if (g_scratchpad.isFormValid) {
+		return true;
+	}
+
+	var actionName = g_form.getActionName();
+	var ga = new GlideAjax('scriptIncludeName');
+	ga.addParam('sysparm_name', 'methodName');
+	ga.addParam('sysparm_additional_parm', 'parmValue');
+	ga.getXMLAnswer(function (answer) {
+		if (answer == 'true') {
+			g_scratchpad.isFormValid = true;
+			// It will trigger the same UI action that was used to submit the form
+			g_form.submit(actionName);
+		}
+	});
+
+	return false;
+}


### PR DESCRIPTION
This snippet simulates the behavior of the getXMLWait method.