### PR TITLE
Email override recipients

### DIFF
--- a/Business Rules/Auto add email recipients to the message body when Email Override is on/IncludeEmailRecipientsInBody.js
+++ b/Business Rules/Auto add email recipients to the message body when Email Override is on/IncludeEmailRecipientsInBody.js
@@ -1,0 +1,25 @@
+//Name: Include email recipients in body
+//Table: Email (sys_email)
+//When: Before
+//Insert: true
+//Update: true
+//Condition: Type is "send-ready"
+
+function onBefore(current, previous) {
+	//Add the recipients to the body of the email so that testers can see who the email was meant for.
+	var recipients = "\n*****\nEmail override is on.  All outbound emails are currently sent to: " + gs.getProperty("glide.email.test.user");
+	recipients += "\nOriginal Intended Recipients: ";
+	if (current.direct != "") {
+		recipients += "\nTO: " + current.direct;
+	}
+	if (current.copied != "") {
+		recipients += "\nCC: " + current.copied;
+	}
+	if (current.blind_copied != "") {
+		recipients += "\nBCC: " + current.blind_copied;
+	}
+	recipients += "\n*****\n";
+	
+	current.body_text = current.body_text + "\n\n\n*****\n" + recipients + "\n*****\n";
+	current.body = current.body + "<html><body><div><br />" + recipients.replace(/\r\n|[\r\n]/g, "<br /></div></body></html>");
+}

--- a/Business Rules/Auto add email recipients to the message body when Email Override is on/readme.md
+++ b/Business Rules/Auto add email recipients to the message body when Email Override is on/readme.md
@@ -1,0 +1,15 @@
+A common complaint I hear about testing email is that people don’t know who was actually supposed to receive emails when the override is on ([glide.email.test.user](https://docs.servicenow.com/bundle/rome-servicenow-platform/page/administer/reference-pages/reference/r_OutboundMailConfiguration.html) property).
+
+The included business rule takes the intended recipients information and puts it in the body of the email at the bottom as shown below. This information can be used by testers to validate that emails would have been sent to the correct recipients.
+
+*****
+Email override is on. All outbound emails are currently sent to: bob.atherton@example.com, ccarter@example.com</br>
+Original Intended Recipients:</br>
+TO: Ray.Hatch@example.com,Ron.deGuzman@example.com,Glen.Traasdahl@example.com</br>
+CC: Cherdell.Singleton@example.com,Ruthe.Aggarwal@example.com</br>
+BCC: Morgan.Avery@example.com</br>
+*****
+
+If there aren’t any CC or BCC recipients those lines will be omitted respectively.
+
+The business rule checks to see if the override is on, so it’s ok to have in a production instance because it won’t apply once they remove the override value.


### PR DESCRIPTION
A common complaint I hear about testing email is that people don’t know who was actually supposed to receive emails when the override is on ([glide.email.test.user](https://docs.servicenow.com/bundle/rome-servicenow-platform/page/administer/reference-pages/reference/r_OutboundMailConfiguration.html) property).

The included business rule takes the intended recipients information and puts it in the body of the email at the bottom as shown below. This information can be used by testers to validate that emails would have been sent to the correct recipients.

*****
Email override is on. All outbound emails are currently sent to: bob.atherton@example.com, ccarter@example.com
Original Intended Recipients:
TO: Ray.Hatch@example.com,Ron.deGuzman@example.com,Glen.Traasdahl@example.com
CC: Cherdell.Singleton@example.com,Ruthe.Aggarwal@example.com
BCC: Morgan.Avery@example.com
*****

If there aren’t any CC or BCC recipients those lines will be omitted respectively.

The business rule checks to see if the override is on, so it’s ok to have in a production instance because it won’t apply once they remove the override value.