### PR TITLE
GlideAjax table and get specific columns

### DIFF
--- a/Script Includes/getTableColumnsClientSide
+++ b/Script Includes/getTableColumnsClientSide
@@ -1,0 +1,42 @@
+var getTableColumnsClientSide = Class.create();
+getTableColumnsClientSide.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+    getColumns: function(tableName, encodedQuery, columns) {
+        var returnData = [];
+        var mappCol = columns.split(',');
+        var fetchColumn = new GlideRecord(tableName);
+        fetchColumn.addEncodedQuery(encodedQuery);
+        fetchColumn.setLimit(1); //Fetch only one record {Check the Query if it return wrong data}
+        fetchColumn.query();
+        if (fetchColumn.next()) {
+
+            for (var i = 0; i < mappCol.length; i++) {
+                var itemCol = {};
+                itemCol[mappCol[i]] = fetchColumn.getValue(mappCol[i].toString());
+                returnData.push(itemCol);
+            }
+
+        }
+        return JSON.stringify(returnData);
+    },
+    getColumnsClient: function() {
+        var tableName = this.getParameter('sysparm_tableName');
+        var encodedQuery = this.getParameter('sysparm_encodedQuery');
+        var columns = this.getParameter('sysparm_columns');
+        var returnData = [];
+        var mappCol = columns.split(',');
+        var fetchColumn = new GlideRecord(tableName);
+        fetchColumn.addEncodedQuery(encodedQuery);
+        fetchColumn.setLimit(1); //Fetch only one record {Check the Query if it return wrong data}
+        fetchColumn.query();
+        if (fetchColumn.next()) {
+            for (var i = 0; i < mappCol.length; i++) {
+                var itemCol = {};
+                itemCol[mappCol[i]] = fetchColumn.getValue(mappCol[i].toString());
+                returnData.push(itemCol);
+            }
+
+        }
+        return JSON.stringify(returnData);
+    },
+    type: 'getTableColumnsClientSide'
+});


### PR DESCRIPTION
A Client Callable script include which will query to the table and will return the set of columns. Below is the example of this code.
Client Side Usage Example:
......................................................
var tableName = 'sys_user';
var user = g_user.userID;
var query = 'sys_id='+user;
var col = 'user_name,email';
var ga = new GlideAjax('getTableColumnsClientSide'); 
ga.addParam('sysparm_name','getColumnsClient'); 
ga.addParam('sysparm_tableName',tableName); 
ga.addParam('sysparm_encodedQuery',query);
ga.addParam('sysparm_columns',col);
ga.getXML(HelloWorldParse);  

function HelloWorldParse(response) {  
   var answer = response.responseXML.documentElement.getAttribute("answer"); 
    alert(answer);
}
Server Side usage example:
....................................................
var gr = new getTableColumnsClientSide();
var user = gs.getUserID();
var query = 'sys_id='+user;
var col = 'user_name,email';
gs.print(gr.getColumns('sys_user',query,col));

Benefit: We can share this scripts usage examples with the regional developer, who don't have access to write custom scripts for catalog client script.