### PR TITLE
added example GlideQuery showing flatmap to create a new query

### DIFF
--- a/GlideQuery/FlatMap to Nest New Queries/getIncidentInfoWithFlatMap.js
+++ b/GlideQuery/FlatMap to Nest New Queries/getIncidentInfoWithFlatMap.js
@@ -1,0 +1,21 @@
+(function () {
+
+	var userQuery = new GlideQuery('sys_user')
+		// Find david.miller's sys_id
+		.where('user_name', 'david.miller')
+		.select('sys_id')
+		.flatMap(function (user) {
+			return new GlideQuery('incident')
+				// Use david.miller's sys_id in a new query on a new table
+				.where('caller_id', user.sys_id)
+				.select([
+					'number',
+					'caller_id.user_name',
+					'state',
+					'assigned_to',
+					'short_description',
+					'priority',
+				]);
+		})
+		.toArray(10);
+})();

--- a/GlideQuery/FlatMap to Nest New Queries/readme.md
+++ b/GlideQuery/FlatMap to Nest New Queries/readme.md
@@ -1,0 +1,7 @@
+# Using FlatMap to Nest Queries
+
+`flatMap` returns a Stream to a parent stream, that cause the parent stream to return the result of the nested Stream.  It is extremely useful for using the results of a query to create and return the results of a new query based on the original's results.
+
+The provided example is slightly contrived, but exhibits this behavior of using the results of a query on one table to create a query on a second table, and then view the output.
+
+It finds uses the `sys_user` table to find the `sys_id` for username = david.miller, then queries the incident table for incidents where the `caller_id` is David Miller's sys_id (from the first query).  The output is the result of the inner query.


### PR DESCRIPTION
This example shows the use of `flatMap` to take the results of a GlideQuery, nest a new GlideQuery based on those results within the parent query, and output the results of the inner query.  It is a very legible way of stringing queries together to get to needed information.