### PR TITLE
Auto-populate watch_list based on caller_id company

### DIFF
--- a/Client Scripts/Auto-populate watch_list based on company/readme.md
+++ b/Client Scripts/Auto-populate watch_list based on company/readme.md
@@ -1,0 +1,5 @@
+Table: Incident
+Type: onChange
+field: caller_id
+
+Sometimes customers have a requirement to add users or distribution lists to all tickets that are raised for their company. This script allows to automatically add a list of users or external email addresses to the watch_list field.

--- a/Client Scripts/Auto-populate watch_list based on company/script.js
+++ b/Client Scripts/Auto-populate watch_list based on company/script.js
@@ -1,0 +1,21 @@
+function onChange(control, oldValue, newValue, isLoading) {
+    if (isLoading) {
+        return;
+    }
+    var callerID = g_form.getReference('caller_id', getUserCompany);
+}
+
+function getUserCompany(callerID) {
+    switch (callerID.company) {
+        case 'company_1_sys_id':
+            g_form.setValue('watch_list', 'PEOPLE_TO_ADD');
+            //PEOPLE_TO_ADD is a comma separated list of user sys_id
+            //and external email addresses
+            break;
+        case 'company_2_sys_id':
+            g_form.setValue('watch_list', 'PEOPLE_TO_ADD');
+            break;
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
Sometimes customers have a requirement to add users or distribution lists to all tickets that are raised for their company. This script allows to automatically add a list of users or external email addresses to the watch_list field.