### PR TITLE
Create ignoremail.js

### DIFF
--- a/Fix scripts/Ignore outbound emails/README.md
+++ b/Fix scripts/Ignore outbound emails/README.md
@@ -1,0 +1,2 @@
+Used to ignore all emails in the system so they are not sent on outbox activation. 
+Run this script prior to enabling email sending to ensure no testing emails are sent upon email activation

--- a/Fix scripts/Ignore outbound emails/ignoremail.js
+++ b/Fix scripts/Ignore outbound emails/ignoremail.js
@@ -1,0 +1,9 @@
+var emailGR = new GlideRecord('sys_email');
+
+emailGR.addQuery('type','send-ready');
+emailGR.query();
+
+while (emailGR.next()) {
+  emailGR.type = 'send-ignored';
+  emailGR.update();
+}


### PR DESCRIPTION
Used to ignore all emails in the system so they are not sent on outbox activation. Run this script prior to enabling email sending to ensure no testing emails are sent upon email activation