### PR TITLE
Copy fields from employee form response to a record

### DIFF
--- a/Business Rules/Copy fields from Employee from/readme.md
+++ b/Business Rules/Copy fields from Employee from/readme.md
@@ -1,0 +1,39 @@
+## Copy response from Employee form to Specific cases/tasks/records
+
+> This BR script can be used when auto field mapping feature on Employee forms is not fitting your requirements
+
+### Usage scenarios
+
+-   There are multiple Active employee forms associated with a single user at a time
+-   Form field to be copied to different cases/tasks/records
+
+### Implementation Guideline
+
+-   Field name on employee form should be same as the field name on the record you want to copy. This is to avoid hard coding of field names/mappings in code and would help to scale the script for any employee form.
+
+ex:
+
+-   Case field name: u_employee_name, Employee form field name: u_employee_name
+
+### Important Note
+
+When a same survey (Employee form) is to be generated for a user who is already assigned to same employee form, then instead of creating new survey instance, OOB, system attaches/associates the existing active survey to the HR tasks. Update the below mentioned business rule to fix this issue.
+
+**BR Name**: Create survey instance
+
+**TODO**: Replace OOB code on line 9 with below code.
+
+```JS
+
+(function executeRule(current, previous /*null when async*/) {
+
+	if(!current.survey || current.survey != previous.survey)
+		if(current.survey_instance) {
+			current.survey_instance.state = 'canceled';
+		}
+
+	if (current.survey)
+		current.survey_instance = (new sn_assessment_core.AssessmentCreation()).createOrGetAssessment(current.survey, "", current.assigned_to);
+})(current, previous);
+
+```

--- a/Business Rules/Copy fields from Employee from/script.js
+++ b/Business Rules/Copy fields from Employee from/script.js
@@ -1,0 +1,87 @@
+(function executeRule(current, previous /*null when async*/) {
+	/**
+	 * This script is user to copy employee field value to any record in case
+	 * This can be used when Employee form auto mapping feature cant be used
+	 * - There are multiple Active employee forms associated with a single user at a time
+	 * - Form field to be copied to different cases/tasks/records
+	 *
+	 */
+
+	var surveyResultTable = "asmt_metric_result";
+	// Employee form surveys linked to Tasks using "survey instance" field
+	var parentGR = new GlideRecord(current.parent.sys_class_name.toString());
+	parentGR.get(current.parent.sys_id.toString());
+
+	var resultGR = new GlideRecord(surveyResultTable);
+	resultGR.addQuery("instance", current.survey_instance.sys_id.toString());
+	resultGR.query();
+	while (resultGR.next()) {
+		var dataType = resultGR.metric.datatype.toString();
+		var fieldName = resultGR.metric.name.toString();
+
+		var value = "";
+		var stringValue = resultGR.string_value.toString();
+		var finalValue = "";
+
+		// Survey response value is saved in different field depending on metric datatype
+		// This section may need to be updated based on different metric type you add in your survey
+		switch (dataType) {
+			case "choice":
+				var tableName = current.parent.sys_class_name.toString();
+				// Get the exact choice "value" to avoid issues with difference in Label and value of field
+				value = "";
+				if (stringValue /*label*/ && fieldName /*element*/ && tableName /*name*/) {
+					var choiceGR = new GlideRecord("sys_choice");
+					choiceGR.addQuery("name", tableName);
+					choiceGR.addQuery("element", fieldName);
+					choiceGR.addQuery("label", stringValue);
+					choiceGR.addQuery("inactive", false);
+					choiceGR.query();
+					if (choiceGR.next()) {
+						value = choiceGR.value.toString();
+					}
+				}
+
+				if (value !== false) {
+					finalValue = value;
+				} else {
+					finalValue = stringValue;
+				}
+				break;
+			case "reference":
+				finalValue = resultGR.reference_value.toString();
+				break;
+			case "date":
+				// finalValue = stringValue;
+				var gdt = new GlideDateTime(stringValue);
+				finalValue = gdt;
+				break;
+			case "string":
+				finalValue = stringValue;
+				break;
+			default:
+				finalValue = stringValue;
+				break;
+		}
+
+		// Setting defaults values for questions based on Default value scenarios
+
+		/**
+		 *
+		 * Employee Form: <Employee Form Name>
+		 * Question: <Question Label>
+		 * Name: <Question name>
+		 * Default Values scenario: <Condition when to set this default value>
+		 * Default Value: <Default value to set>
+		 *
+		 * */
+		if (fieldName == "u_employee_tile" && finalValue == "") {
+			parentGR.setValue("u_employee_name", "Intern");
+		}
+
+		parentGR.setValue(fieldName, finalValue);
+		// parentGR[fieldName] = finalValue; (this is the same as above)
+	}
+
+	parentGR.update();
+})(current, previous);


### PR DESCRIPTION
## Copy response from Employee form to Specific cases/tasks/records

> This BR script can be used when the auto field mapping feature on Employee forms is not fitting your requirements

### Usage scenarios

-   There are multiple Active employee forms associated with a single user at a time
-   Form field to be copied to different cases/tasks/records