### PR TITLE
create incident task modal and automatically link to incident

### DIFF
--- a/UI Actions/Create incident task and relate to incident/readme.md
+++ b/UI Actions/Create incident task and relate to incident/readme.md
@@ -1,0 +1,11 @@
+This UI Action loads a modal for to create a new incident task that is linked to the incident that you generated it from.
+
+Suggested values:
+Name: Create Incident Task
+Table: Incident
+Client: true
+List v2: true
+Form Link: true
+
+Onclick: createIncidentTask()
+Condition: current.state != 7

--- a/UI Actions/Create incident task and relate to incident/script.js
+++ b/UI Actions/Create incident task and relate to incident/script.js
@@ -1,0 +1,14 @@
+function createIncidentTask() {
+	
+	var sysID = g_form.getUniqueValue();
+	
+	var gm = new GlideModalForm('Create Incident Task', 'incident_task');
+	gm.setPreference('focusTrap', true);
+	gm.setPreference('table', 'incident_task');
+	gm.setPreference('sysparm_query', 'incident='+sysID);
+	gm.setWidth(650);
+
+	//Opens the dialog
+	gm.render();
+	
+}


### PR DESCRIPTION
This UI Action loads a modal form to create a new incident task that is linked to the incident that you generated it from.
