### PR TITLE
BackfillAssignmentGroup Script Include

### DIFF
--- a/Script Includes/BackfillAssignmentGroup/BackfillAssignmentGroup.js
+++ b/Script Includes/BackfillAssignmentGroup/BackfillAssignmentGroup.js
@@ -1,0 +1,43 @@
+var BackfillAssignmentGroup = Class.create();
+BackfillAssignmentGroup.prototype = {
+  initialize: function () {},
+
+  BackfillAssignmentGroup: function () {
+    var groups = " ";
+    var assignee = current.assigned_to;
+
+    //return all relevant groups (active, itil) if the assigned_to value is empty
+
+    if (!assignee) {
+      var allGrp = new GlideRecord("sys_user_group");
+      allGrp.addActiveQuery();
+      allGrp.addEncodedQuery("typeLIKE1cb8ab9bff500200158bffffffffff62"); //group is constrained to 'itil' type. You can change this to meet your requirements
+      allGrp.query();
+      while (allGrp.next()) {
+        //build a comma separated string of groups if there is more than one
+        if (groups.length > 0) {
+          groups += "," + rgrp.sys_id;
+        } else {
+          groups = rgrp.sys_id;
+        }
+      }
+      return "sys_idIN" + groups;
+    }
+    //sys_user_grmember has the user to group relationship
+    var userGrp = new GlideRecord("sys_user_grmember");
+    userGrp.addQuery("user", assignee);
+    userGrp.addEncodedQuery("group.typeLIKE1cb8ab9bff500200158bffffffffff62"); //group is constrained to 'itil' type. You can change this to meet your requirements
+    userGrp.query();
+    while (userGrp.next()) {
+      if (groups.length > 0) {
+        //build a comma separated string of groups if there is more than one
+        groups += "," + userGrp.group;
+      } else {
+        groups = userGrp.group;
+      }
+    }
+    // return Groups where assigned to is in those groups we use IN for lists
+    return "sys_idIN" + groups;
+  },
+  type: "BackfillAssignmentGroup",
+};

--- a/Script Includes/BackfillAssignmentGroup/readme.md
+++ b/Script Includes/BackfillAssignmentGroup/readme.md
@@ -1,0 +1,18 @@
+# BackFillAssignmentGroup
+
+This script include is an advanced reference qualifier for the Assignment group field. It restricts the Assignment group choices to only relevant groups of which the current Assigned to user is a member.
+
+## Current Configuration
+
+The script include filters for groups with the OOTB **type** of "itil" assigned to them (generally considered fulfiller groups). As such, it's ideal for use on the base Task and its extended tables (Incident, Problem, Change). Note that the **type** field is a list and the values should be queried by sys_id. It would be simple to modify the script to constrain the field to different roles or other attribute.
+
+## Use
+
+Configure the dictionary entry of the assignment_group field on Task table.
+
+1. Type **task.list** into the navigator and press **Enter**.
+2. Right-click any column name and select **Configure>Table**.
+3. Select **Advanced View** under **Related Links** if not already.
+4. Under the **Reference Specification** tab, set **Use reference qualifier** to **Advanced**.
+5. In the **Reference qual** field, enter: **javascript:new BackfillAssignmentGroup().BackfillAssignmentGroup()**
+6. Save

--- a/Script Includes/BackfillAssignmentGroup/readme.md
+++ b/Script Includes/BackfillAssignmentGroup/readme.md
@@ -8,6 +8,12 @@ The script include filters for groups with the OOTB **type** of "itil" assigned 
 
 ## Use
 
+1. Create a script include called **BackfillAssignmentGroup**.
+2. Set **Accessible from** to **This application scope only**.
+3. Add description **Links assignment group field to assigned to field so that only the groups of which the assigned to is a member will be displayed for selection.** or write your own.
+4. Paste the entire contents of the script file into the **Script** field.
+5. Save.
+
 Configure the dictionary entry of the assignment_group field on Task table.
 
 1. Type **task.list** into the navigator and press **Enter**.


### PR DESCRIPTION
Restricts the assignment group field to the current assigned to user's memberships. A blank assigned to will show all fields that match the filter (active, type itil).