### PR TITLE
Quick current

### DIFF
--- a/Background Scripts/Attach Workflow to Existing Record/readme.md
+++ b/Background Scripts/Attach Workflow to Existing Record/readme.md
@@ -1,0 +1,3 @@
+# Attach Workflow to existing records
+
+This background script can be useful if you run into a situation where the workflow condition did not trigger on an intended record, or an older version of a workflow had a flaw but the record already began fulfillment.

--- a/Background Scripts/Attach Workflow to Existing Record/script.js
+++ b/Background Scripts/Attach Workflow to Existing Record/script.js
@@ -1,0 +1,16 @@
+//add table name, encrypted query, and workflow sys_id you want to attach to the record(s)
+
+//example data
+var table = "sc_req_item";
+var encQuery =
+  "active=true^cat_item=a01e54b3dbb46340cd5af9041d961958^numberINRITM0028376,RITM0028370,RITM0028310,RITM0028234,RITM0028385)";
+var workflow_sys_id = "[enter workflow sys_id here]";
+
+var task = new GlideRecord(table);
+task.addEncodedQuery(encQuery);
+task.query();
+
+while (task.next()) {
+  var wf = new Workflow();
+  var context = wf.startFlow(workflow_sys_id, task, task.update());
+}

--- a/Background Scripts/QuickCurrent/quickCurrent.js
+++ b/Background Scripts/QuickCurrent/quickCurrent.js
@@ -1,0 +1,9 @@
+var table = "sc_req_item"; //Requested item
+var sid = "[Insert record sys_id]";
+var current = new GlideRecord(table);
+current.get(sid);
+var vars = current.variables; //Short-hand access to variables to check values before/after running the script
+//ex: vars.requested_for, vars.color, vars.desired_delivery_date
+gs.info(current.number + "\n" + current.short_description); //display record number and short description
+
+//##### Enter script using 'current' below this line #####

--- a/Background Scripts/QuickCurrent/readme.md
+++ b/Background Scripts/QuickCurrent/readme.md
@@ -1,0 +1,12 @@
+# QuickCurrent
+
+I use this all the time to test out workflow or business rule script logic without having to go through end-to-end testing of a catalog item workflow or fill out mandatory fields or approvals multiple times just to make sure a complex script has the desired output.
+
+By having a quick snippet to create a "current" variable, there is no need to modify the script that may be retrieving or setting values on "current" in the workflow or business rule.
+
+## Use
+
+1. Create the desired record and ensure all needed values are filled in.
+2. Enter the table name in the **table** variable (sc_req_item is default)
+3. Copy and paste the sys_id from the test record into the **sid** variable
+4. Paste script below the comment and run to see if it works as expected


### PR DESCRIPTION
Quickly create a "current" variable for a record to test against in a background script for a workflow or business rule without modifying to fit the destination. Great for workflows where current.variables.xyz is retrieved or set a lot.