### PR TITLE
Autopopulate department

### DIFF
--- a/Background Scripts/Attach Workflow to Existing Record/readme.md
+++ b/Background Scripts/Attach Workflow to Existing Record/readme.md
@@ -1,0 +1,3 @@
+# Attach Workflow to existing records
+
+This background script can be useful if you run into a situation where the workflow condition did not trigger on an intended record, or an older version of a workflow had a flaw but the record already began fulfillment.

--- a/Background Scripts/Attach Workflow to Existing Record/script.js
+++ b/Background Scripts/Attach Workflow to Existing Record/script.js
@@ -1,0 +1,16 @@
+//add table name, encrypted query, and workflow sys_id you want to attach to the record(s)
+
+//example data
+var table = "sc_req_item";
+var encQuery =
+  "active=true^cat_item=a01e54b3dbb46340cd5af9041d961958^numberINRITM0028376,RITM0028370,RITM0028310,RITM0028234,RITM0028385)";
+var workflow_sys_id = "[enter workflow sys_id here]";
+
+var task = new GlideRecord(table);
+task.addEncodedQuery(encQuery);
+task.query();
+
+while (task.next()) {
+  var wf = new Workflow();
+  var context = wf.startFlow(workflow_sys_id, task, task.update());
+}

--- a/Background Scripts/List fields in table/listFieldsInTable.js
+++ b/Background Scripts/List fields in table/listFieldsInTable.js
@@ -1,0 +1,41 @@
+var table = [
+  "cmdb_ci_netgear",
+  "cmdb_ci_firewall_network",
+  "cmdb_ci_ip_firewall",
+  "cmdb_ci_switch",
+  "cmdb_ci_ip_router",
+  "cmdb_ci_computer",
+  "cmdb_ci_hardware",
+  "cmdb_ci_lb",
+  "cmdb_ci_lb_interface",
+  "cmdb_ci_lb_pool",
+  "cmdb_ci_lb_pool_member",
+  "cmdb_ci_lb_service",
+  "cmdb_ci_vlan",
+  "cmdb_ci_server",
+  "cmdb_ci_linux_server",
+  "cmdb_ci_win_server",
+  "cmdb_ci_ups",
+];
+
+for (var i = 0; i < table.length; i++) {
+  gs.print("<<<<<-------START TABLE------->>>>>");
+  gs.print("TABLE " + table[i]);
+  getFields("alm_asset");
+  gs.print("<<<<<-------END TABLE------->>>>>\n\n");
+}
+
+function getFields(table) {
+  var i = 0;
+
+  var gr = new GlideRecord("sys_dictionary");
+
+  gr.addQuery("name", table);
+
+  gr.query();
+  gs.print("Row, Field name, Display name");
+  while (gr.next()) {
+    i = i + 1;
+    gs.print("Field " + i + ": " + gr.element + " (" + gr.column_label + ")");
+  }
+}

--- a/Background Scripts/List fields in table/readme.md
+++ b/Background Scripts/List fields in table/readme.md
@@ -1,0 +1,11 @@
+# Get Fields in Table
+
+Quick script to print out the fields on one or multiple tables. Especialy helpful for CMBD tables when a stakeholder inevitably asks "Can you send me a list of all the tables and fields?
+
+## Use
+
+Simply add the table names from you wish to display the fields in the **table** array.
+
+## Current Configuration
+
+A demo list of CMDB tables is included. The script will list the fields numbered, in alphabetical order, and includes actual field name and label name.

--- a/Background Scripts/QuickCurrent/quickCurrent.js
+++ b/Background Scripts/QuickCurrent/quickCurrent.js
@@ -1,0 +1,9 @@
+var table = "sc_req_item"; //Requested item
+var sid = "[Insert record sys_id]";
+var current = new GlideRecord(table);
+current.get(sid);
+var vars = current.variables; //Short-hand access to variables to check values before/after running the script
+//ex: vars.requested_for, vars.color, vars.desired_delivery_date
+gs.info(current.number + "\n" + current.short_description); //display record number and short description
+
+//##### Enter script using 'current' below this line #####

--- a/Background Scripts/QuickCurrent/readme.md
+++ b/Background Scripts/QuickCurrent/readme.md
@@ -1,0 +1,12 @@
+# QuickCurrent
+
+I use this all the time to test out workflow or business rule script logic without having to go through end-to-end testing of a catalog item workflow or fill out mandatory fields or approvals multiple times just to make sure a complex script has the desired output.
+
+By having a quick snippet to create a "current" variable, there is no need to modify the script that may be retrieving or setting values on "current" in the workflow or business rule.
+
+## Use
+
+1. Create the desired record and ensure all needed values are filled in.
+2. Enter the table name in the **table** variable (sc_req_item is default)
+3. Copy and paste the sys_id from the test record into the **sid** variable
+4. Paste script below the comment and run to see if it works as expected

--- a/Catalog Client Script/Autopopulate Department/autopopulateDepartment.js
+++ b/Catalog Client Script/Autopopulate Department/autopopulateDepartment.js
@@ -1,0 +1,7 @@
+function onChange(control, oldValue, newValue, isLoading) {
+  g_form.getReference("requested_for", function (gr) {
+    g_form.setValue("department", gr.department);
+    g_form.setValue("email", gr.email);
+    g_form.setValue("phone", gr.phone);
+  });
+}

--- a/Catalog Client Script/Autopopulate Department/readme.md
+++ b/Catalog Client Script/Autopopulate Department/readme.md
@@ -1,0 +1,9 @@
+# Autopopulate Department Catalog Client Script
+
+Use this onChange catalog client script to populate a **department** variable in a catalog item based on a modifiable **requested_for**. Both variables must be reference type pointing to their respective tables.
+
+## Use case
+
+The GlideUser API (g_user) does not provide a way to retrieve a user's department in a client-side script. Here is a small snippet using `g_form.getReference()` to retrieve the user from the **requested_for** variable and populate the **department** variable in a catalog item while allowing the submitter to still change the department if the data is incorrect.
+
+Attach this client script to a variable set for easy reuse. It can be augmented with a number of other fields from the user record such as email, phone number, manager, etc. Just be mindful of field types and whether the desired field will return a sys_id or display text.


### PR DESCRIPTION
Client script fills a gap where GlideUser API falls short. Allows you to capture the department (or other fields) from the user record in a requested_for reference variable.