### PR TITLE
Provide shortcuts for typing commonly used code

### DIFF
--- a/Syntax Editor Macros/Client Side Ajax Call/ajax.js
+++ b/Syntax Editor Macros/Client Side Ajax Call/ajax.js
@@ -1,0 +1,10 @@
+// Ajax call
+var ga = new GlideAjax('script_include'); // Script Include
+ga.addParam('sysparm_name', 'function'); // Function
+ga.addParam('sysparm_value', newValue);
+ga.getXMLAnswer(callBackParse);
+
+// Callback function
+function callBackParse(response) {
+	//Your code goes here	
+}

--- a/Syntax Editor Macros/Documentation Header/doc.js
+++ b/Syntax Editor Macros/Documentation Header/doc.js
@@ -1,0 +1,8 @@
+/**
+* Description: $0
+ 
+* Parameters: 
+ 
+* Returns: 
+*/
+ 

--- a/Syntax Editor Macros/For Each Statement/foreach.js
+++ b/Syntax Editor Macros/For Each Statement/foreach.js
@@ -1,0 +1,6 @@
+for (property in event) {
+    //code block to be executed
+    if (condition) { //optional if statement
+        continue; //skip the rest of the code and go to next property in the event
+    }
+}

--- a/Syntax Editor Macros/For Statement/for.js
+++ b/Syntax Editor Macros/For Statement/for.js
@@ -1,0 +1,4 @@
+for(var i = 0; i < variable_name.length; i++) {
+	//Your code goes here
+	//variable_name[i]; 
+}

--- a/Syntax Editor Macros/Function Statement/function.js
+++ b/Syntax Editor Macros/Function Statement/function.js
@@ -1,0 +1,3 @@
+(function() {
+	//Your code goes here
+})();

--- a/Syntax Editor Macros/GlideRecord Or Query/vargror.js
+++ b/Syntax Editor Macros/GlideRecord Or Query/vargror.js
@@ -1,0 +1,8 @@
+var gr = new GlideRecord('$0');
+var qc = gr.addQuery('field', 'value1');
+qc.addOrCondition('field', 'value2');
+gr.query();
+
+while (gr.next()) {
+
+}

--- a/Syntax Editor Macros/If Statement/if.js
+++ b/Syntax Editor Macros/If Statement/if.js
@@ -1,0 +1,5 @@
+if (CONDITION) {
+	//block of code to be executed if the condition is true
+} else { 
+	//block of code to be executed if the condition is false
+}

--- a/Syntax Editor Macros/Loop While Statement/while.js
+++ b/Syntax Editor Macros/Loop While Statement/while.js
@@ -1,0 +1,3 @@
+while (condition) {
+	//code block to be executed
+}

--- a/Syntax Editor Macros/Server Script GlideAggregate Query/count.js
+++ b/Syntax Editor Macros/Server Script GlideAggregate Query/count.js
@@ -1,0 +1,9 @@
+var ga = new GlideAggregate('table_name');
+ga.addQuery('field_name', 'field_value');
+ga.addAggregate('COUNT');
+ga._query();
+
+if(ga._next()) {
+	//Your code goes here
+	//ga.getAggregate('COUNT')
+}

--- a/Syntax Editor Macros/Server Script GlideRecord Encoded Query/encoded.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Encoded Query/encoded.js
@@ -1,0 +1,8 @@
+var queryStr = 'active=true';
+var gr = new GlideRecord("$0");
+gr.addEncodedQuery(queryStr);
+gr.query();
+
+while (gr.next()) {
+   // Do something with the record(s) returned
+}

--- a/Syntax Editor Macros/Server Script GlideRecord Get Query/get.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Get Query/get.js
@@ -1,0 +1,5 @@
+var gr = new GlideRecord('$0');
+
+if(gr.get('sys_id')) {
+	//Your code goes here
+}

--- a/Syntax Editor Macros/Server Script GlideRecord Insert Query/insert.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Insert Query/insert.js
@@ -1,0 +1,4 @@
+var gr = new GlideRecord("$0");
+gr.newRecord();
+gr.setValue('field_name', 'field_value');
+gr.insert();

--- a/Syntax Editor Macros/Server Script GlideRecord Query (Single Record)/setlimit.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Query (Single Record)/setlimit.js
@@ -1,0 +1,8 @@
+var gr = new GlideRecord('$0');
+gr.addQuery('field_name', 'field_value');
+gr.setLimit(1);
+gr.query();
+
+if(gr._next()) {
+	//Your code goes here
+}

--- a/Syntax Editor Macros/Server Script GlideRecord Query/query.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Query/query.js
@@ -1,0 +1,7 @@
+var gr = new GlideRecord("$0");
+gr.addQuery('field_name', 'field_value');
+gr.query();
+
+while (gr.next()) {
+   // Do something with the record(s) returned
+}

--- a/Syntax Editor Macros/Server Script GlideRecord Update Query/update.js
+++ b/Syntax Editor Macros/Server Script GlideRecord Update Query/update.js
@@ -1,0 +1,7 @@
+var gr = new GlideRecord("$0");
+gr.addQuery('field_name', 'field_value');
+gr.query();
+while (gr.next()) {
+	gr.setValue('field_name', 'field_value'); //set field values
+    gr.update();
+}

--- a/Syntax Editor Macros/Switch Statement/switch.js
+++ b/Syntax Editor Macros/Switch Statement/switch.js
@@ -1,0 +1,12 @@
+var conditionStr = '';
+
+switch(conditionStr) {
+	case 0:
+		// Your code goes here
+		break;
+	case 1:
+		// Your code goes here
+		break;
+	default:
+		// Your code goes here
+}

--- a/Syntax Editor Macros/Try Catch Statement/trycatch.js
+++ b/Syntax Editor Macros/Try Catch Statement/trycatch.js
@@ -1,0 +1,9 @@
+// Try / Catch
+try {
+	//block of code to try
+} catch(err) {
+	//block of code to handle errors
+	//ex: gs.info('ERROR');
+} finally {
+	//block of code to be executed regardless of the try / catch result
+}

--- a/Syntax Editor Macros/readme.md
+++ b/Syntax Editor Macros/readme.md
@@ -1,0 +1,1 @@
+Script macros provide shortcuts for typing commonly used code. To insert macro text into a script field, enter the macro keyword into the script editor, followed by a tab.


### PR DESCRIPTION
Script macros provide shortcuts for typing commonly used code. To insert macro text into a script field, enter the macro keyword into the script editor, followed by a tab.