### PR TITLE
Add UI Action and Related Records for Cross-Instance navigation

### DIFF
--- a/UI Actions/Open Record in Alternate Instance/RESTMessageV2/sys_rest_message_config.md
+++ b/UI Actions/Open Record in Alternate Instance/RESTMessageV2/sys_rest_message_config.md
@@ -1,0 +1,4 @@
+Name: Cross-Instance Record Checking
+Endpoint: [An Instance Url]/api/[api subpath, i.e., riot]/recordapi/record_exists
+
+See `sys_rest_message_fn_config.md` for HTTP Method setup.

--- a/UI Actions/Open Record in Alternate Instance/RESTMessageV2/sys_rest_message_fn_config.md
+++ b/UI Actions/Open Record in Alternate Instance/RESTMessageV2/sys_rest_message_fn_config.md
@@ -1,0 +1,10 @@
+Name: [Target Instance] Record Exists
+HTTP Method: PATCH
+Endpoint: [Target Instance Url]/api/[api subpath]/.../record_exists
+
+HTTP Request Parameters:
+
+    {
+        "table": "${table}",
+        "sysId": "${sysId}"
+    }

--- a/UI Actions/Open Record in Alternate Instance/Script Includes/readme.md
+++ b/UI Actions/Open Record in Alternate Instance/Script Includes/readme.md
@@ -1,0 +1,2 @@
+
+!! The switch statement in CrossInstanceHelper.js will need to be reconfigured to match instance names, and RESTMessage naming.

--- a/UI Actions/Open Record in Alternate Instance/Script Includes/sys_script_include.js
+++ b/UI Actions/Open Record in Alternate Instance/Script Includes/sys_script_include.js
@@ -1,0 +1,60 @@
+var CrossInstanceHelper = Class.create();
+CrossInstanceHelper.prototype = {
+    initialize: function() {
+    },
+	
+	//Defines a filter so that tables that will never exist in other environments are not checked.
+	_goodTable: function(table){
+		
+		var disallowedTables = [
+			'sys_update_set_source',
+			'sys_update_set',
+			'sys_email',
+			'syslog'
+		];
+		
+		//If the table is disallowed, return false
+		if(disallowedTables.indexOf(table) != -1) return false;
+		
+		//If the table extends task, or extends a table that extends task, return false
+		return !(new TableUtils('task').getTableExtensions().indexOf(table) != -1 || new TableUtils(table).getAbsoluteBase() == 'task');
+	},
+	
+	exists: function(instance, table, sys_id){
+		
+		//If the table is disallowed, return
+		if(!_goodTable(table)) return false;
+		
+		//Determine endpoint from instance
+		var endpoint;
+		instance = instance.toLowerCase();
+
+        /*
+            These are example instance names and their corresponding endpoints. You will need to add your own instances and endpoints here.
+        */
+		switch(instance){
+			case 'prod':
+				endpoint = 'PROD Exists';
+				break;
+			case 'test':
+				endpoint = 'TEST Exists';
+				break;
+			case 'dev':
+				endpoint = 'DEV Exists';
+				break;
+		}
+		
+		//Build the REST Message
+		var r = new sn_ws.RESTMessageV2('Cross-Instance Record Checking', endpoint);
+		r.setStringParameterNoEscape('table', table);
+		r.setStringParameterNoEscape('sysId', sys_id);
+		
+		//Execute the request
+		var response = r.execute();
+		
+		//Return whether or not the record exists (true if it exists)
+		return(response.getStatusCode().toString() == '200');
+	},
+
+    type: 'CrossInstanceHelper'
+};

--- a/UI Actions/Open Record in Alternate Instance/Script Includes/sys_script_include_config.md
+++ b/UI Actions/Open Record in Alternate Instance/Script Includes/sys_script_include_config.md
@@ -1,0 +1,4 @@
+Name: CrossInstanceHelper
+Client callable: false
+
+Script: See `sys_script_include.js` for code.

--- a/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_definition_config.md
+++ b/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_definition_config.md
@@ -1,0 +1,9 @@
+General:
+
+    Name: RecordAPI
+    API ID: recordapi
+
+Content Negotiation:
+
+    Supported request formats: application/json,application/xml,text/xml
+    Supported response formats: application/json,application/xml,text/xml

--- a/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_operation/sys_ws_operation.js
+++ b/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_operation/sys_ws_operation.js
@@ -1,0 +1,32 @@
+(function process(/*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
+
+	function isNull(obj){
+		return(obj == '' || obj == undefined  || obj == 'undefined' || obj == null || obj == 'null');
+	}
+
+	//Get data from request
+	var requestBody = request.body;
+	var requestData = requestBody.data;
+	
+	//Get table name from request
+	var tableName = requestData.table;
+
+	//Get sys_id from request
+	var sysId = requestData.sysId;
+
+	//Make sure data exists
+	if(isNull(tableName) || isNull(tableName.toString()) || isNull(sysId) || isNull(sysId.toString())){
+		response.setStatus(400);
+		return;
+	}
+	
+	//Start lookup
+	var rGr = new GlideRecord(tableName);
+	rGr.get('sys_id', sysId);
+
+	var recordExists = !rGr.sys_id == '';
+
+	response.setBody(recordExists ? "Resource exists." : "Resource does not exist.");
+	response.setStatus(recordExists ? 200 : 404);
+
+})(request, response);

--- a/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_operation/sys_ws_operation_config.md
+++ b/UI Actions/Open Record in Alternate Instance/Scripted REST API/sys_ws_operation/sys_ws_operation_config.md
@@ -1,0 +1,11 @@
+General:
+
+    HTTP Method: PATCH
+    Relative Path: /record_exists
+
+Content Negotiation:
+
+    Request formats: application/json,application/xml,text/xml
+    Response formats: application/json,application/xml,text/xml
+
+Script: see `sys_ws_operation.js` for code.

--- a/UI Actions/Open Record in Alternate Instance/UI Action/sys_ui_action.js
+++ b/UI Actions/Open Record in Alternate Instance/UI Action/sys_ui_action.js
@@ -1,0 +1,13 @@
+function openInInstance(){
+
+    //Since we are in a client action, get the current record utilizing the URL
+    if(!top.location) return;
+    var href = top.location.href.toString();
+
+    //Grab record from current URL
+    var recordHref = href.split('.com/')[1];
+
+    //Open the record in the new instance
+    window.open('https://[Target Instance].service-now.com/nav_to.do?uri=' + recordHref, '_blank');
+
+}

--- a/UI Actions/Open Record in Alternate Instance/UI Action/sys_ui_action_config.md
+++ b/UI Actions/Open Record in Alternate Instance/UI Action/sys_ui_action_config.md
@@ -1,0 +1,19 @@
+!! If your instances use vanity urls, or otherwise do not end in `.com`, the `split()` in code.js will need to be edited
+
+Name: Open Record in [Target Instance]
+Table: Global [global]
+Action Name: Open Record in [Target Instance]
+
+Client: true
+List v2 Compatible: true
+List v3 Compatible: true
+
+Isolate script: false
+
+Onclick: openInInstance()
+
+Condition:
+
+    gs.getProperty('[Target Instance]') != '[target instance name]' && !current.isNewRecord() && new CrossInstanceHelper().exists('[Target Instance]', current.getTableName(), current.sys_id.toString())
+
+Script: See `sys_ui_action.js` for code.

--- a/UI Actions/Open Record in Alternate Instance/readme.md
+++ b/UI Actions/Open Record in Alternate Instance/readme.md
@@ -1,0 +1,19 @@
+This set of:
+
+- RESTMessage
+- Script Includes
+- Scripted REST API (SRAPI)
+- UI Action
+
+Will allow you to open a record in alternate corresponding instance(s) of ServiceNow.
+For example, from a record in a PROD instance, you can open the correlating record in your DEV instance.
+
+The 'Starting Instance', refers to the instance you are currently in, and the 'Target Instance' refers to the instance you want to open the record in.
+Any instance of `[Target Instance]` in these files will need to be replaced.
+
+- The RESTMessage will need to exist on the 'Starting' Instance
+- The Script Includes will need to exist on the 'Starting' Instance
+- The UI Action will need to exist on the 'Starting' Instance
+- The SRAPI will need to exist on the Target Instance
+
+Any file ending in `_config.md` relates to field configuration of the record.


### PR DESCRIPTION
This is a UI Action function that is meant to be used to open records in other related ServiceNow instances.

If this would better fit somewhere besides code-snippets, or if it should not be pulled in, feel free to reject.

Commits:

- Add code and configuration for UI Action, RESTMessageV2, SRAPI, and Script Includes, as well as READMEs where applicable.