### PR TITLE
PerformanceAnalyticsUtils Script Include

### DIFF
--- a/Script Includes/PerformanceAnalyticsUtils/PerformanceAnalyticsUtils.js
+++ b/Script Includes/PerformanceAnalyticsUtils/PerformanceAnalyticsUtils.js
@@ -1,0 +1,40 @@
+var PerformanceAnalyticsUtils = Class.create();
+PerformanceAnalyticsUtils.prototype = {
+	
+    initialize: function() {
+    },
+
+	/**SNDOC
+		@name getCmdbClassTableNames
+		@description Retrieve an array of all the child classes from a start class
+		
+		@param {string} [startClassTableName]
+		
+		@returns {array} An array of all child classes from the start class downwards
+	*/
+	
+	getCmdbClassTableNames: function(startClassTableName) {
+		
+		var dbObjectIds = [];
+		
+		// From the start table sys_class_path, get the child tables
+		
+		var grDbObjectStart = new GlideRecord('sys_db_object');
+		if (grDbObjectStart.get('name', startClassTableName)) {
+			
+			var grDbObjectChild = new GlideRecord('sys_db_object');
+			grDbObjectChild.addQuery('sys_class_path', 'CONTAINS', grDbObjectStart.getValue('sys_class_path'));
+			grDbObjectChild.query();
+		
+			// Put all the child table sys_id's into the returned array
+			while (grDbObjectChild.next()) {
+				dbObjectIds.push(grDbObjectChild.getUniqueValue());
+			}
+			
+		}
+		
+		return dbObjectIds;
+		
+	},	
+    type: 'PerformanceAnalyticsUtils'
+};

--- a/Script Includes/PerformanceAnalyticsUtils/readme.md
+++ b/Script Includes/PerformanceAnalyticsUtils/readme.md
@@ -1,0 +1,11 @@
+# Performance Analytics Utils
+
+A Script Include to gather methods for handling Performance Analytics subjects. Typical use case is to be invoked by PA Scripts (for custom aggregation or breakdown mappings).
+
+## getCmdbClassTableNames
+
+Returns sys_id's of all the tables (sys_db_object) starting -and including- a start class. This is very useful to build a PA Breakdown on CMDB Classes. This method is fast as it uses the sys_class_path field to query sys_db_object.
+
+This is a replacement for SNC.CMDBUtil.getAllChildrenOfAsCommaList() that I did not manage to invoke from Breakdown Source record Condition Builder (was getting an illegal access error because of the SNC scope).
+
+I understand this also could be in an CMDBUtil Script Include, but I found very useful for building a PA Breakdown Source.


### PR DESCRIPTION
A Script Include to gather methods for handling Performance Analytics subjects. Typical use case is to be invoked by PA Scripts (for custom aggregation or breakdown mappings).

I did not find any other Script Include for this domain so I thought I would create one and have one function I keep needing when building PA indicators on CMDB: a CMDB Class Breakdown.
