### PR TITLE
This script helps to get Table Name and related field Names in ServiceNow.

### DIFF
--- a/DisplayTableNameandfieldName.js
+++ b/DisplayTableNameandfieldName.js
@@ -1,0 +1,14 @@
+var arr =[];
+var getTableAndFieldNames = new GlideRecord('sys_dictionary');
+getTableAndFieldNames.addEncodedQuery('internal_type!=collection');
+getTableAndFieldNames.orderBy('name');
+getTableAndFieldNames.query();
+while(getTableAndFieldNames.next())
+{
+arr.push("Table Name : " + getTableAndFieldNames.name.toString() + ", Label Name : " +getTableAndFieldNames.column_label.toString()+ ", Backend Label Name : "+ getTableAndFieldNames.element.toString());
+}
+
+for(var i=0; i<arr.length; i++)
+{
+   gs.print(arr[i]);
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,9 @@
+##Display Table names and field names
+This script helps to know all the table names and field values with just few lines of code. 
+
+##Use
+When stakeholder wants to know list and table and field values which are using in servicenow, then this script will be helpful a lot even for integrations and a quick timesaver.
+
+##Alternative
+Need to follow some manual process to get these details. 
+


### PR DESCRIPTION
After executing this script the users can get all details of table names along with field names in servicenow.. when stakeholders want to know suddenly (or) at the time of integrations this script will help a lot and also we can modify the code to restrict it to a single table.