### PR TITLE
Calculate Attachment Hash using GlideDigest

### DIFF
--- a/Attachments/Calculate attachment hash code/calculateHash.js
+++ b/Attachments/Calculate attachment hash code/calculateHash.js
@@ -1,0 +1,9 @@
+function calculateHash(attachmentId){
+    var attachmentStream = new GlideSysAttachment().getContentStream(attachmentId);
+    var gDigest = new GlideDigest();
+    var sha256Hash = gDigest.getSHA256HexFromInputStream(attachmentStream);
+    if (sha256Hash) {
+        gs.info("Hash code of the attachment file: " + sha256Hash);
+    }
+}
+

--- a/Attachments/Calculate attachment hash code/readme.md
+++ b/Attachments/Calculate attachment hash code/readme.md
@@ -1,0 +1,8 @@
+This is example of recalculate the hash code using the glide digest getSHA256HexFromInputStream method.
+
+GlideDigest() -
+    This class provides methods for creating a message digest from strings or input streams using MD5, SHA1, or SHA256 hash algorithms.
+
+Docs link: https://developer.servicenow.com/dev.do#!/reference/api/tokyo/server/no-namespace/c_GlideDigestScopedAPI#r_SGDigest-GlideDigest
+
+getSHA256HexFromInputStream - function takes GlideScriptableInputStream input stream as parameter.


### PR DESCRIPTION
Calculate Attachment Hash using [GlideDigest](https://developer.servicenow.com/dev.do#!/reference/api/tokyo/server/no-namespace/c_GlideDigestScopedAPI#r_SGDigest-GlideDigest)