### PR TITLE
Remote table script

### DIFF
--- a/GlideQuery/Remote Table/Readme.md
+++ b/GlideQuery/Remote Table/Readme.md
@@ -1,0 +1,2 @@
+This script is used to combine 2 internal tables:sc_req_item and sc_item_produced_record from a Report Table Definition => Script tab. 
+We can create a report on the created remote table (Pie chart). 

--- a/GlideQuery/Remote Table/remotetabldef.js
+++ b/GlideQuery/Remote Table/remotetabldef.js
@@ -1,0 +1,24 @@
+(function executeQuery(v_table, v_query) {
+    var months = 12; //This value should be set in a system property. 
+    var startDate = gs.monthsAgo(months);
+
+    addUsage('sc_req_item', 'cat_item.name'); //You might want to group by sys_id instead of name
+    addUsage('sc_item_produced_record', 'producer.name'); //You might want to group by sys_id instead of name
+
+    function addUsage(table, groupBy) {
+        new GlideQuery(table)
+            .where('sys_created_on', '>', startDate)
+            .aggregate('count')
+            .groupBy(groupBy)
+            .select()
+            .forEach(function(result) {
+                v_table.addRow({
+                    u_count: result.count,
+                    u_name: result.group[groupBy],
+                    u_type: table
+                });
+
+            });
+
+    }
+})(v_table, v_query);


### PR DESCRIPTION
This script is used to combine 2 internal tables:sc_req_item and sc_item_produced_record from a Report Table Definition => Script tab. We can also create a report (Eg:Pie Chart) on top of this new Remote Table as well. 