### PR TITLE
Variables order adjustment on catalog item

### DIFF
--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -1,0 +1,20 @@
+# Adjust Variable Order on Catalog Item
+
+This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.
+We all know the struggle, that initially we set up variables with fixed order steps such as 100, 200, 300, 400 ... 
+However, over time, additional variables are inserted in between, resulting in a messy looking order (e.g. 10, 15, 50, 55, 100, 200, 350, 300, 400). 
+This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort. 
+
+### Instruction
+
+At the beginning of the script you have to set the Sys ID of the Catalog Item or Variable Set where you want to re-order the variables.
+The Script is build in a way, that this Sys ID can belong to either a Variable Set or Catalog Item.
+Furthermore, you have to define the step size for the order. My recommendation would be to use 100.
+ 
+```javascript
+var sys_id = "e0ecd03947e29110d3c0c789826d4332"; //provide a catalog item or variable set sys id
+var step_size = 100; //the step size for the new order
+```
+
+### Benefits
+

--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -1,8 +1,8 @@
 # Adjust Variable Order on Catalog Item
 
 This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.  
-We all know the struggle, that initially we set up variables with fixed order steps such as 100, 200, 300, 400 ...   
-However, over time, additional variables are inserted in between, resulting in a messy looking order (e.g. 10, 15, 50, 55, 100, 200, 350, 300, 400).   
+We all know the struggle, that initially we set up variables with fixed order steps such as: 100, 200, 300, 400 ...   
+However, over time, additional variables are inserted in between, resulting in a messy looking order, e.g.: 10, 15, 50, 55, 100, 200, 350, 300, 400 ... 
 This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort.   
 
 ### Instruction

--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -8,7 +8,7 @@ This fix script should enable developers to keep their Catalog Items clean and s
 ### Instruction
 
 At the beginning of the script you have to set the Sys ID of the Catalog Item or Variable Set where you want to re-order the variables.
-The Script is build in a way, that this Sys ID can belong to either a Variable Set or Catalog Item.
+The Script is built in a way, that this Sys ID can belong to either a Variable Set or Catalog Item.
 Furthermore, you have to define the step size for the order. My recommendation would be to use 100.
  
 ```javascript

--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -1,8 +1,8 @@
 # Adjust Variable Order on Catalog Item
 
 This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.  
-We all know the struggle, that initially we set up variables with fixed order steps such as: 100, 200, 300, 400 ...   
-However, over time, additional variables are inserted in between, resulting in a messy looking order, e.g.: 10, 15, 50, 55, 100, 200, 350, 300, 400 ... 
+We all know the struggle, that initially we set up variables with fixed order steps such as: 100, 200, 300, 400    
+However, over time, additional variables are inserted in between, resulting in a messy looking order, e.g.: 10, 15, 50, 55, 100, 200, 350, 300, 400   
 This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort.   
 
 ### Instruction
@@ -17,4 +17,7 @@ var step_size = 100; //provide the step size for the new order
 ```
 
 ### Benefits
+
+- Keep Catalog Items and Variable Sets celan and structured
+- Reduce efforts maintaining variable orders
 

--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -3,7 +3,7 @@
 This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.  
 We all know the struggle, that initially we set up variables with fixed order steps such as: 100, 200, 300, 400    
 However, over time, additional variables are inserted in between, resulting in a messy looking order, e.g.: 10, 15, 50, 55, 100, 200, 350, 300, 400   
-This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort.   
+This fix script should enable developers to keep their Catalog Items clean and structured, with minimal effort.   
 
 ### Instruction
 
@@ -18,6 +18,6 @@ var step_size = 100; //provide the step size for the new order
 
 ### Benefits
 
-- Keep Catalog Items and Variable Sets celan and structured
+- Keep Catalog Items and Variable Sets clean and structured
 - Reduce efforts maintaining variable orders
 

--- a/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/readme.md
@@ -1,9 +1,9 @@
 # Adjust Variable Order on Catalog Item
 
-This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.
-We all know the struggle, that initially we set up variables with fixed order steps such as 100, 200, 300, 400 ... 
-However, over time, additional variables are inserted in between, resulting in a messy looking order (e.g. 10, 15, 50, 55, 100, 200, 350, 300, 400). 
-This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort. 
+This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set.  
+We all know the struggle, that initially we set up variables with fixed order steps such as 100, 200, 300, 400 ...   
+However, over time, additional variables are inserted in between, resulting in a messy looking order (e.g. 10, 15, 50, 55, 100, 200, 350, 300, 400).   
+This fix script should enable developers to keep their Catalog Items celan and structured, whith minimal effort.   
 
 ### Instruction
 
@@ -13,7 +13,7 @@ Furthermore, you have to define the step size for the order. My recommendation w
  
 ```javascript
 var sys_id = "e0ecd03947e29110d3c0c789826d4332"; //provide a catalog item or variable set sys id
-var step_size = 100; //the step size for the new order
+var step_size = 100; //provide the step size for the new order
 ```
 
 ### Benefits

--- a/Fix scripts/Adjust Variable Order on Catalog Item/script.js
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/script.js
@@ -1,0 +1,29 @@
+
+//set the following variables before running the script
+var sys_id = "e0ecd03947e29110d3c0c789826d4332"; //provide a catalog item or variable set sys id
+var step_size = 5000; //provide the step size for the new order
+
+
+if (sys_id) { //avoid updating all records with empty fields for catalog item or variable set
+    var variables = new GlideRecord("item_option_new");
+	variables.addQuery("cat_item", sys_id).addOrCondition('variable_set', sys_id);
+    variables.orderBy("order");
+    variables.query();
+
+    if (variables.hasNext()) {
+		var i =0;
+        while (variables.next()) {
+            variables.order.setValue(i*step_size);
+            variables.update();
+			i++;
+        }
+		gs.log("The order of " + i + " variables has been changed, ranging now from 0 to " + (i-1)*step_size);
+    }
+	else{
+		gs.log("No Variables were found for the provided catalog item or variable set sys id");
+	}
+
+} else {
+    gs.log("Please provide a catalog item or variable set sys id in line 1");
+}
+

--- a/Fix scripts/Adjust Variable Order on Catalog Item/script.js
+++ b/Fix scripts/Adjust Variable Order on Catalog Item/script.js
@@ -1,7 +1,7 @@
 
 //set the following variables before running the script
 var sys_id = "e0ecd03947e29110d3c0c789826d4332"; //provide a catalog item or variable set sys id
-var step_size = 5000; //provide the step size for the new order
+var step_size = 100; //provide the step size for the new order
 
 
 if (sys_id) { //avoid updating all records with empty fields for catalog item or variable set


### PR DESCRIPTION
This will add a new Script to the Fix Script folder. This Fix Script helps developers to automatically re-order all variables of a given Catalog Item or Variable Set. For example, reordering a messy order such as: 10, 15, 50, 55, 100, 200, 350 to a clean one with equal steps of 100 resulting in: 0, 100, 200, 300, 400, 400, 500. 