### PR TITLE
Get Field Label in Specific Language

### DIFF
--- a/Script Includes/Get Field Label in Specific Language/readme.md
+++ b/Script Includes/Get Field Label in Specific Language/readme.md
@@ -1,0 +1,19 @@
+# Get Field Label in Specific Language
+
+This Script Include enables retrieving the label of a certain table field in any given language. 
+Often in multi-language instances, the label of a field must be printed via a script. Instead of retrieving the value each time individually this script include can be re-used (e.g. by multiple Business Rules or Mail Scripts) 
+
+### Instruction
+
+Call the Script Include via the following example code from any server-side script (e.g. Business Rule, Mail Script or Flow Action). If you want, you can also make the script include client callable and make it available to client scripts. Make sure to provide the correct table name, field name and language in your function call. Be aware, that in some cases the field may be on a parent table. In this case you would have to provide the parent table name to the script. 
+
+```javascript
+var util =new LanguageUtils();
+gs.log(util.getLabel("incident", "category", "de"));
+```
+
+
+### Benefits
+- If no label in the provided language can be found, the default English label is returned
+- Re-use this script include and call t from different types of script (e.g. Business Rule, Mail Script or Flow Action)
+

--- a/Script Includes/Get Field Label in Specific Language/readme.md
+++ b/Script Includes/Get Field Label in Specific Language/readme.md
@@ -1,7 +1,7 @@
 # Get Field Label in Specific Language
 
 This Script Include enables retrieving the label of a certain table field in any given language. 
-Often in multi-language instances, the label of a field must be printed via a script. Instead of retrieving the value each time individually this script include can be re-used (e.g. by multiple Business Rules or Mail Scripts) 
+Often in multi-language instances, the label of a field must be accessed via a script (e.g. to add it to the HTML of an email or add it to another fields like the description or work notes). Instead of retrieving the value each time individually this script include can be re-used (e.g. by multiple Business Rules or Mail Scripts) 
 
 ### Instruction
 

--- a/Script Includes/Get Field Label in Specific Language/readme.md
+++ b/Script Includes/Get Field Label in Specific Language/readme.md
@@ -1,7 +1,7 @@
 # Get Field Label in Specific Language
 
 This Script Include enables retrieving the label of a certain table field in any given language. 
-Often in multi-language instances, the label of a field must be accessed via a script (e.g. to add it to the HTML of an email or add it to another fields like the description or work notes). Instead of retrieving the value each time individually this script include can be re-used (e.g. by multiple Business Rules or Mail Scripts) 
+Often in multi-language instances, the label of a field must be accessed via a script (e.g. to add it to the HTML of an email or add it to another fields like the description or work notes). Instead of retrieving the value each time individually this script include can be re-used (e.g. by multiple Business Rules or Mail Scripts). 
 
 ### Instruction
 

--- a/Script Includes/Get Field Label in Specific Language/readme.md
+++ b/Script Includes/Get Field Label in Specific Language/readme.md
@@ -5,7 +5,7 @@ Often in multi-language instances, the label of a field must be printed via a sc
 
 ### Instruction
 
-Call the Script Include via the following example code from any server-side script (e.g. Business Rule, Mail Script or Flow Action). If you want, you can also make the script include client callable and make it available to client scripts. Make sure to provide the correct table name, field name and language in your function call. Be aware, that in some cases the field may be on a parent table. In this case you would have to provide the parent table name to the script. 
+Call the Script Include via the following example code from any server-side script (e.g. Business Rule, Mail Script or Flow Action). If you want, you can also make the Script Include client callable and make it available to Client Scripts. Make sure to provide the correct table name, field name and language in your function call. Be aware, that in some cases the field may be located on a parent table. In this case, you would have to provide the parent table name to the script. 
 
 ```javascript
 var util =new LanguageUtils();
@@ -15,5 +15,5 @@ gs.log(util.getLabel("incident", "category", "de"));
 
 ### Benefits
 - If no label in the provided language can be found, the default English label is returned
-- Re-use this script include and call t from different types of script (e.g. Business Rule, Mail Script or Flow Action)
+- Re-use this Script Include and call it from different types of scripts (e.g. Business Rule, Mail Script or Flow Action)
 

--- a/Script Includes/Get Field Label in Specific Language/script.js
+++ b/Script Includes/Get Field Label in Specific Language/script.js
@@ -1,20 +1,22 @@
 var LanguageUtils = Class.create();
 LanguageUtils.prototype = {
-  
     getLabel: function(table, variable, language) {
+
         var grLabel = new GlideRecord("sys_documentation");
         grLabel.addQuery("name", table);
         grLabel.addQuery("element", variable);
         grLabel.addQuery("language", language);
         grLabel.query();
+
         if (grLabel.next()) {
             return grLabel.getValue("label");
-        } else {
+        } else { //if no label in the given language can be found return the default English label instead
             var grEnLabel = new GlideRecord("sys_documentation");
             grEnLabel.addQuery("name", table);
             grEnLabel.addQuery("element", variable);
-            grEnLabel.addQuery("language", "en"); //default language English
+            grEnLabel.addQuery("language", "en");
             grEnLabel.query();
+
             if (grEnLabel.next()) {
                 gs.log("The variable " + variable + " does not have a label in " + language + " associated to it, in the following table: +" + table);
                 return grEnLabel.getValue("label");
@@ -22,6 +24,7 @@ LanguageUtils.prototype = {
                 gs.log("The variable " + variable + " can not be found in the following table: +" + table);
                 return;
             }
+
         }
     },
 

--- a/Script Includes/Get Field Label in Specific Language/script.js
+++ b/Script Includes/Get Field Label in Specific Language/script.js
@@ -1,0 +1,29 @@
+var LanguageUtils = Class.create();
+LanguageUtils.prototype = {
+  
+    getLabel: function(table, variable, language) {
+        var grLabel = new GlideRecord("sys_documentation");
+        grLabel.addQuery("name", table);
+        grLabel.addQuery("element", variable);
+        grLabel.addQuery("language", language);
+        grLabel.query();
+        if (grLabel.next()) {
+            return grLabel.getValue("label");
+        } else {
+            var grEnLabel = new GlideRecord("sys_documentation");
+            grEnLabel.addQuery("name", table);
+            grEnLabel.addQuery("element", variable);
+            grEnLabel.addQuery("language", "en"); //default language English
+            grEnLabel.query();
+            if (grEnLabel.next()) {
+                gs.log("The variable " + variable + " does not have a label in " + language + " associated to it, in the following table: +" + table);
+                return grEnLabel.getValue("label");
+            } else {
+                gs.log("The variable " + variable + " can not be found in the following table: +" + table);
+                return;
+            }
+        }
+    },
+
+    type: 'LanguageUtils'
+};


### PR DESCRIPTION
This Script Include enables retrieving the label of a certain table field in any given language. Often in multi-language instances, the label of a field must be accessed via a script (e.g. to add it to the HTML of an email or add it to another fields like the description or work notes).