### PR TITLE
New bookmarklet: open copied property

### DIFF
--- a/Browser Bookmarklets/Open copied record/open copied record bookmarklet.js
+++ b/Browser Bookmarklets/Open copied record/open copied record bookmarklet.js
@@ -1,0 +1,1 @@
+javascript: (c=> c.readText().then( text => window.open("http://" + window.location.hostname + "/nav_to.do?uri=task.do?sysparm_query=number=" + text, "_blank")))(navigator.clipboard);

--- a/Browser Bookmarklets/Open copied record/readme.md
+++ b/Browser Bookmarklets/Open copied record/readme.md
@@ -1,0 +1,12 @@
+## Open copied record
+
+Someone sent you the Number of a record that belong to the task table (e.g. Incident, SCTASK, RITM, Story, Problem, Change etc.), but not a link to the record itself?
+
+You can save yourself a couple of clicks if you use this Bookmarklet while you are on the instance that the record belongs to.
+
+**Usage**:
+- copy the record number,
+- make sure that in your browser you are on the same instance that the record belongs to,
+- click the Bookmarklet, and the record's form will open in a new tab (with a visible navigation pane).
+
+I use this Bookmarklet on a daily basis, hope you'll like it as well.


### PR DESCRIPTION
## Open copied record

Someone sent you the Number of a record that belong to the task table (e.g. Incident, SCTASK, RITM, Story, Problem, Change etc.), but not a link to the record itself?

You can save yourself a couple of clicks if you use this Bookmarklet while you are on the instance that the record belongs to.

Usage:
- copy the record number,
- make sure that in your browser you are on the same instance that the record belongs to,
- click the Bookmarklet, and the record's form will open in a new tab (with a visible navigation pane).

I use this Bookmarklet on a daily basis, hope you'll like it as well.