### PR TITLE
Remove reference icon from portal using Catalog Client script of a Ca…

### DIFF
--- a/Catalog Client Script/Remove reference icon from portal/README.md
+++ b/Catalog Client Script/Remove reference icon from portal/README.md
@@ -1,0 +1,6 @@
+# Remove reference icon from portal using Catalog Client script of a Catalog Item
+
+This catalog client script is design to remove the reference icon from the Portal for any reference field record.
+This needs to be configured for each Catalog Item where the reference field is being used.
+
+* [Click here for script](remove-reference-icon-from-portal-onLoad.js)

--- a/Catalog Client Script/Remove reference icon from portal/remove-reference-icon-from-portal-onLoad.js
+++ b/Catalog Client Script/Remove reference icon from portal/remove-reference-icon-from-portal-onLoad.js
@@ -1,0 +1,9 @@
+function onLoad() {
+    setTimeout(function() {
+        var referenceElement = top.document.getElementsByClassName('btn btn-default bg-white lookup')[0];
+
+        if (referenceElement != undefined || referenceElement != null)
+            referenceElement.remove();
+        
+    }, 500);
+}


### PR DESCRIPTION
…talog Item

This catalog client script is design to remove the reference icon from the Portal for any reference field record. This needs to be configured for each Catalog Item where the reference field is being used.