### PR TITLE
Retrieve Last Comment By Ticket

### DIFF
--- a/Script Includes/Retrieve Last Comment by Ticket/RetrieveLastCommentByTicket.js
+++ b/Script Includes/Retrieve Last Comment by Ticket/RetrieveLastCommentByTicket.js
@@ -1,0 +1,22 @@
+var RetrieveLastCommentByTicket = Class.create();
+RetrieveLastCommentByTicket.prototype = {
+    initialize: function() {},
+	
+    retrieveLastCommentByTicket: function(sysId, tableName) {
+        var lastComment = new GlideRecord('sys_journal_field');
+
+        lastComment.addQuery('name', tableName);
+        lastComment.addQuery('element_id', sysId);
+        lastComment.addQuery('element', 'comments');
+        lastComment.orderByDesc('sys_created_on');
+        lastComment.setLimit(1);
+        lastComment.query();
+
+        if (lastComment.next())
+            return lastComment;
+
+        return null;
+    },
+
+    type: 'RetrieveLastCommentByTicket'
+};

--- a/Script Includes/Retrieve Last Comment by Ticket/readme.md
+++ b/Script Includes/Retrieve Last Comment by Ticket/readme.md
@@ -1,0 +1,7 @@
+# Retrieve Last Comment By Ticket
+
+This script returns the last comment that has been added on a ticket by the record id.
+The function 'retrieveLastCommentByTicket' requires two arguments
+
+    Argument #1: sys_id - this is the sys_id of the record from which you need to pick the last comment
+    Argument #2: tableName - this is the table name of the record


### PR DESCRIPTION
This script returns the last comment that has been added on a ticket by the record id. The function 'retrieveLastCommentByTicket' requires two arguments

    Argument #1: sys_id - this is the sys_id of the record from which you need to pick the last comment
    Argument #2: tableName - this is the table name of the record