### PR TITLE
Decrypt password field

### DIFF
--- a/Background Scripts/Decrypt Password Field/decryptfield.js
+++ b/Background Scripts/Decrypt Password Field/decryptfield.js
@@ -1,10 +1,11 @@
 //Remember to run this in the global scope
 
+//Get the record that has the password2 field.
 var getBasicAuthGR = new GlideRecord('basic_auth_credentials');
 getBasicAuthGR.get('INSERT_SYS_ID');
- 
-var Encrypter = new GlideEncrypter();  
 
+//Decrypt the password and show it.
+var Encrypter = new GlideEncrypter();  
 var decryptedPassword= Encrypter.decrypt(getBasicAuthGR.password);
 
 gs.info("password is: " + decryptedPassword);//Remember this also ends up in the logfile.

--- a/Background Scripts/Decrypt Password Field/decryptfield.js
+++ b/Background Scripts/Decrypt Password Field/decryptfield.js
@@ -1,0 +1,10 @@
+//Remember to run this in the global scope
+
+var getBasicAuthGR = new GlideRecord('basic_auth_credentials');
+getBasicAuthGR.get('INSERT_SYS_ID');
+ 
+var Encrypter = new GlideEncrypter();  
+
+var decryptedPassword= Encrypter.decrypt(getBasicAuthGR.password);
+
+gs.info("password is: " + decryptedPassword);//Remember this also ends up in the logfile.

--- a/Background Scripts/Decrypt Password Field/readme.md
+++ b/Background Scripts/Decrypt Password Field/readme.md
@@ -1,3 +1,5 @@
-Sometimes we forget what the password we are using in e.g. the Credentials records for integrations. 
+Sometimes we forget the password we are using e.g. the Credentials records for integrations. 
+With this code, you can go into the "basic_auth_credentials" table and decrypt the field "password" which is of the type password2.
+The API GlideEncrypter does only work in the Global scope.
 
-With this code you can go into the "basic_auth_credentials" table and decrypt the field "password" which is of the type password2.
+

--- a/Background Scripts/Decrypt Password Field/readme.md
+++ b/Background Scripts/Decrypt Password Field/readme.md
@@ -1,0 +1,3 @@
+Sometimes we forget what the password we are using in e.g. the Credentials records for integrations. 
+
+With this code you can go into the "basic_auth_credentials" table and decrypt the field "password" which is of the type password2.

--- a/Server Side/Decrypt Password2 Field/decryptPassword2.js
+++ b/Server Side/Decrypt Password2 Field/decryptPassword2.js
@@ -1,4 +1,0 @@
-var Encrypter = new GlideEncrypter();  
-var encrypted = glideRecordVar.getValue('password'); // current.<<your field name>>   
-var decrypted = Encrypter.decrypt(encrypted);  
-gs.info("decrypted..   " + decrypted);

--- a/Server Side/Decrypt Password2 Field/readme.md
+++ b/Server Side/Decrypt Password2 Field/readme.md
@@ -1,1 +1,0 @@
-decrypterPassword2.js will dycrpt a password2 field


### PR DESCRIPTION
This code snippet can be run as a background script to retrieve a password that you have forgotten and exists in the "basic_auth_credentials" table. It goes in and decrypts the password field and shows what value it has.

I have removed a similar version in the Server Side category since there now is one in the Background Scripts folder where you will probably be running the code snippet. The Code snippet in there is also more documented