### PR TITLE
Create RemovePublicRolesFromReports.js

### DIFF
--- a/Scheduled Jobs/Remove Public Reports/RemovePublicRolesFromReports.js
+++ b/Scheduled Jobs/Remove Public Reports/RemovePublicRolesFromReports.js
@@ -1,0 +1,12 @@
+var pubReport = new GlideRecord('sys_report');
+pubReport.addQuery('is_published=true^ORroles=public');
+pubReport.query();
+while(pubReport.next()) {
+    //Obtain current roles report is shared with
+	var removePublic = pubReport.roles;
+    //Remove public role from string
+	removePublic = removePublic.replace(/public/g, '');
+    //Set report roles to new string value. Wihtout public role, report will auto unpublish
+	pubReport.roles.setValue(removePublic);
+	pubReport.update();
+}


### PR DESCRIPTION
Scheduled job to unpublish public reports. This only removes the public role, other roles, groups and users are maintained. This is intended to prevent internal/senstivate data being made public/users without authentication to your instance.