### PR TITLE
Open modal widget onsubmit

### DIFF
--- a/Catalog Client Script/Open modal widget in an Onsubmit/openmodal.js
+++ b/Catalog Client Script/Open modal widget in an Onsubmit/openmodal.js
@@ -1,0 +1,53 @@
+    function onSubmit() {
+
+      
+        if (g_scratchpad.isFormValid)
+            return true;
+
+      //We can do some check using a Client Callable script include
+        var getAnswer = new GlideAjax('example');
+        getAnswer.addParam('sysparm_name', 'checkFor');
+        getAnswer.addParam('sysparm_input1', g_user.userID);
+        getAnswer.addParam('sysparm_input2', g_form.getUniqueValue());
+
+        getAnswer.getXML(parsing);
+
+        function parsing(response) {
+
+            var answer = response.responseXML.documentElement.getAttribute('answer');
+            if (answer) {
+                var data = JSON.parse(answer);
+          
+                if (data == true) {
+
+                    spModal.open({
+                        title: "Test title",
+                        widget: "mywidget",
+                        buttons: [{
+                                label: 'Close',
+                                value: 'close'
+                            },
+                            {
+                                label: 'Create New Record',
+                                value: 'create'
+                            }
+                        ],
+                        size: 'md'
+                    }).then(function(answer) {
+                      //if button pressed is "create" then submit the form
+                        if (answer.value == 'create') {
+                            g_scratchpad.isFormValid = true;
+                            g_form.submit();
+                        }
+                    });
+                } else {
+                    g_scratchpad.isFormValid = true;
+                    g_form.submit();
+                }
+
+            }
+
+        }
+      //Dont submit the form
+        return false;
+    }

--- a/Catalog Client Script/Open modal widget in an Onsubmit/readme.md
+++ b/Catalog Client Script/Open modal widget in an Onsubmit/readme.md
@@ -1,3 +1,1 @@
 Code snippet to stop submission of a form in an Onsubmit Client Script, use an asynchronous call, and open a Widget in Modal view. In the script provided, there are two buttons in the modal. The first continues with the submission to create a new record and the second one cancels it. We can use a Script Include to get some value that we want and based on that open the modal or continue with submission.
-
-A use case might be to check for active cases of the logged-in user. If there is an active case for the same HR service he is trying to submit the case for we can stop the submission of the record producer and showcase in the widget a list of all the active cases of that user. In that way, we can prevent duplication in a user-friendly way.

--- a/Catalog Client Script/Open modal widget in an Onsubmit/readme.md
+++ b/Catalog Client Script/Open modal widget in an Onsubmit/readme.md
@@ -1,0 +1,3 @@
+Code snippet to stop submission of a form in an Onsubmit Client Script, use an asynchronous call, and open a Widget in Modal view. In the script provided, there are two buttons in the modal. The first continues with the submission to create a new record and the second one cancels it. We can use a Script Include to get some value that we want and based on that open the modal or continue with submission.
+
+A use case might be to check for active cases of the logged-in user. If there is an active case for the same HR service he is trying to submit the case for we can stop the submission of the record producer and showcase in the widget a list of all the active cases of that user. In that way, we can prevent duplication in a user-friendly way.


### PR DESCRIPTION
This can be used in an Onsubmit catalog client script to stop submission of the form and open a widget in a modal view. This also uses an async call to fetch some data that may be necessary and based on that open the modal (using SPModal) or continue with the submission.