### PR TITLE
Return user asset util

### DIFF
--- a/GlideAjax/Return Asset(s) for User/FindUserAsset.js
+++ b/GlideAjax/Return Asset(s) for User/FindUserAsset.js
@@ -1,0 +1,64 @@
+var getUserAsset = Class.create();
+getUserAsset.prototype = Object.extendsObject(global.AbstractAjaxProcessor, {
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////Return 1 Asset Any Model//////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////	
+
+    getOneAsset: function() {
+
+        var userSys = this.getParameter('sysparm_user');
+
+        var mAsset = new GlideRecord('alm_hardware');
+        mAsset.addQuery("assigned_to", userSys);
+        mAsset.setLimit(1);
+        mAsset.query();
+        while (mAsset.next()) {
+            var astID = mAsset.sys_id;
+        }
+        return astID;
+
+    },
+
+    /////////////////////////////////////////////////////////////////////////////////////////
+ //////////////////////Return 1 with specific Model Category////////////////////////////
+ ///////////////////////////////////////////////////////////////////////////////////////
+
+    getAssetCustom: function() {
+
+        var userSys = this.getParameter('sysparm_user');
+        var astCat = this.getParameter('sysparm_category');
+
+        var mAsset = new GlideRecord('alm_hardware');
+        mAsset.addEncodedQuery('model_category=' + astCat + '^assigned_to=' + userSys);
+        mAsset.setLimit(1);
+        mAsset.query();
+        while (mAsset.next()) {
+            var astID = mAsset.sys_id;
+        }
+        return astID;
+
+    },
+
+    /////////////////////////////////////////////////////////////////////////////////////////
+ ///////// Reutns All Assets for User////////////////////////////////////////////////////
+ ///////////////////////////////////////////////////////////////////////////////////////
+
+    getAllAssets: function() {
+
+        var userSys = this.getParameter('sysparm_user');
+        var aList = [];
+
+        var mAsset = new GlideRecord('alm_hardware');
+        mAsset.addQuery("assigned_to", userSys);
+        mAsset.setLimit(20); //Set Limi to 20 to prevent too many returns in case of a generic account/blank account is passed.
+        mAsset.query();
+        while (mAsset.next()) {
+            alist.push(mAsset.sys_id);
+        }
+        return aList;
+
+    },
+
+
+    type: 'getUserAsset'
+});

--- a/GlideAjax/Return Asset(s) for User/readme.md
+++ b/GlideAjax/Return Asset(s) for User/readme.md
@@ -1,0 +1,9 @@
+Client Callable GlideAjax script include to return one of the Following based on passed user's sys_id:
+
+-Single Asset for User
+
+-Single Asset for User with Model Category filtering
+
+-All Assets for User
+
+Script queries the "alm_hardware" table. Intended to be called from a client script/catalog client script, one use case would be to populate a users asset on a catalog item form.


### PR DESCRIPTION
**Code Description**

Client Callable GlideAjax script include to return one of the Following based on passed user's sys_id:

-Single Asset for User

-Single Asset for User with Model Category filtering

-All Assets for User

Script queries the "alm_hardware" table. Intended to be called from a client script/catalog client script, one use case would be to populate a users asset on a catalog item form.


**Files Included**

New folder "Return Asset(s) for User" under "GlideAjax"
Script: "FindUserAsset.js"
Readme file: "readme.md"

**Notes**

Opening a new pull request as my pull request form yesterday did not include a readme.md