### PR TITLE
Run Subscription Job On Demand

### DIFF
--- a/Fix scripts/Run Subscription Job On Demand/code.js
+++ b/Fix scripts/Run Subscription Job On Demand/code.js
@@ -1,0 +1,2 @@
+var summarizer = new SNC.SubscriptionSummarizer();
+summarizer.runSummary();

--- a/Fix scripts/Run Subscription Job On Demand/readme.md
+++ b/Fix scripts/Run Subscription Job On Demand/readme.md
@@ -1,0 +1,7 @@
+# Usage
+If you wish to update/re-calculate your allocated entitlements on the subscription management dashboard, execute the following two lines of code. You can run this server script either in the background script or maintain it as a fix script and run it on-demand.
+
+```
+var summarizer = new SNC.SubscriptionSummarizer();
+		             summarizer.runSummary();
+```


### PR DESCRIPTION
If you wish to update/re-calculate your allocated entitlements on the subscription management dashboard, execute the following two lines of code. You can run this server script either in the background script or maintain it as a fix script and run it on-demand.