### PR TITLE
Reference lookup form behaviour control

### DIFF
--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -1,12 +1,15 @@
 **Use Case**
+
 Clicking the lookup icon on a reference field opens a table's list view.
 On clicking the 'new' button to create new records on the reference table, system displays the 'Default' view for that table.
 There might be a requirement to control the form's behaviour when the new record form is opened from a specific field on a specific table.
 
 **Usage**
+
 Write a client script/scripted UI policy on the reference table and add the code in "script.js" file.
 
 **Explanation**
+
 The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked.
 Key parameters of interest here:
   - **sysparm_nameofstack**: "reflist" ==> Will always be reflist when form has originated from a reference lookup icon click

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -1,14 +1,14 @@
-**Use Case**
+## **Use Case**
 
 Clicking the lookup icon on a reference field opens a table's list view.
 On clicking the 'new' button to create new records on the reference table, system displays the 'Default' view for that table.
 There might be a requirement to control the form's behaviour when the new record form is opened from a specific field on a specific table.
 
-**Usage**
+## **Usage**
 
 Write a client script/scripted UI policy on the reference table and add the code in "script.js" file.
 
-**Explanation**
+## **Explanation**
 
 The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked.
 Key parameters of interest here:

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -1,14 +1,14 @@
-## **Use Case**
+# Use Case
 
 Clicking the lookup icon on a reference field opens a table's list view.
 On clicking the 'new' button to create new records on the reference table, system displays the 'Default' view for that table.
 There might be a requirement to control the form's behaviour when the new record form is opened from a specific field on a specific table.
 
-## **Usage**
+# Usage
 
 Write a client script/scripted UI policy on the reference table and add the code in "script.js" file.
 
-## **Explanation**
+# Explanation
 
 The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked.
 Key parameters of interest here:

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -1,0 +1,13 @@
+**Use Case**
+Clicking the lookup icon on a reference field opens a table's list view.
+On clicking the 'new' button to create new records on the reference table, system displays the 'Default' view for that table.
+There might be a requirement to control the form's behaviour when the new record form is opened from a specific field on a specific table.
+
+**Usage**
+Write a client script/scripted UI policy on the reference table and add the code in "script.js" file.
+
+**Explanation**
+The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked.
+Key parameters of interest here:
+  - **sysparm_nameofstack**: "reflist" ==> Will always be reflist when form has originated from a reference lookup icon click
+  - **sysparm_target**: "change_request.cmdb_ci" ==> Will be in the format <table_name>.<field_name>

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -1,16 +1,15 @@
 # Use Case
 
-Clicking the lookup icon on a reference field opens a table's list view.
-On clicking the 'new' button to create new records on the reference table, system displays the 'Default' view for that table.
-There might be a requirement to control the form's behaviour when the new record form is opened from a specific field on a specific table.
+Clicking the lookup icon on a reference field opens the list view for the referenced table. On clicking the 'New' button to create new records on the reference table, 'Default' form view for that table is displayed. There might be a requirement to control the form's behaviour when the new record form is opened from a designated field on a specific table.
+
 
 # Usage
 
-Write a client script/scripted UI policy on the reference table and add the code in "script.js" file.
+Write a client script/scripted UI policy on the reference table and add the code in ```script.js``` file.
+
 
 # Explanation
 
-The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked.
-Key parameters of interest here:
-  - **sysparm_nameofstack**: "reflist" ==> Will always be reflist when form has originated from a reference lookup icon click
-  - **sysparm_target**: "change_request.cmdb_ci" ==> Will be in the format <table_name>.<field_name>
+The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked. These parameters can be extracted using the client-side class ```GlideURL```. Key parameters of interest here:
+  - ```**sysparm_nameofstack**: "reflist"``` ==> Will always be reflist when form has originated from a reference lookup icon click
+  - ```**sysparm_target**: "change_request.cmdb_ci"``` ==> Will be in the format <table_name>.<field_name>

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/README.md
@@ -11,5 +11,5 @@ Write a client script/scripted UI policy on the reference table and add the code
 # Explanation
 
 The URL parameters contains the necessary information about the originating table and field from where the lookup icon is clicked. These parameters can be extracted using the client-side class ```GlideURL```. Key parameters of interest here:
-  - ```**sysparm_nameofstack**: "reflist"``` ==> Will always be reflist when form has originated from a reference lookup icon click
-  - ```**sysparm_target**: "change_request.cmdb_ci"``` ==> Will be in the format <table_name>.<field_name>
+  - ```sysparm_nameofstack: "reflist"``` ==> Will always be reflist when form has originated from a reference lookup icon click
+  - ```sysparm_target: "change_request.cmdb_ci"``` ==> Will be in the format <table_name>.<field_name>

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/script.js
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/script.js
@@ -6,5 +6,5 @@ var field = url.getParam('sysparm_target'); //Dot-walked path to the field (Exam
 
 if (source === 'reflist' && field === 'change_request.cmdb_ci') {
 	// Add form control logic here
-	g_form.setMandatory('name', false);
+	g_form.setMandatory('name', true);
 }

--- a/Client Scripts/Control Form Behaviour from Reference Lookup/script.js
+++ b/Client Scripts/Control Form Behaviour from Reference Lookup/script.js
@@ -1,0 +1,10 @@
+
+var url = new GlideURL();
+url.setFromCurrent();
+var source = url.getParam('sysparm_nameofstack'); // Always 'reflist' when opening from Reference Lookup Icon
+var field = url.getParam('sysparm_target'); //Dot-walked path to the field (Example: cmdb_ci field on change_request form - change_request.cmdb_ci)
+
+if (source === 'reflist' && field === 'change_request.cmdb_ci') {
+	// Add form control logic here
+	g_form.setMandatory('name', false);
+}


### PR DESCRIPTION
This client-side code snippet allows to control form behaviour when a new record form is opened from the list view displayed by clicking the lookup icon of a reference field.

There might be a requirement to control the form's behaviour when the new record form is opened from a designated field on a specific table.


The provided code snippet can be used in a client script/scripted UI policy defined on the reference table and allows usage of client-side APIs.

**Path to newly added folder: Client Scripts/Control Form Behaviour from Reference Lookup**