### PR TITLE
feat(get_glide_record): get GlideRecord for a reference field

### DIFF
--- a/Background Scripts/Get GlideRecord Reference Field/get_glide_record_reference_field.js
+++ b/Background Scripts/Get GlideRecord Reference Field/get_glide_record_reference_field.js
@@ -1,0 +1,7 @@
+var grApproval = new GlideRecord('sysapproval_approver');
+grApproval.get('007a44badba52200a6a2b31be0b8f525');
+
+if(grApproval.sysapproval.getRefRecord().isValidRecord()) { 
+   return grApproval.sysapproval.getRefRecord();
+}
+

--- a/Background Scripts/Get GlideRecord Reference Field/readme.md
+++ b/Background Scripts/Get GlideRecord Reference Field/readme.md
@@ -1,0 +1,3 @@
+# Get GlideRecord to a reference field using getRefRecord() method
+
+**Use case** : Background script that retrieves the complete record of a reference field


### PR DESCRIPTION
# Get GlideRecord to a reference field using getRefRecord() method

**Use case** : Background script that retrieves the complete record of a reference field