### PR TITLE
Fetch field value on list view on client

### DIFF
--- a/Client Scripts/Get Field Value From List on Client/README.md
+++ b/Client Scripts/Get Field Value From List on Client/README.md
@@ -1,0 +1,17 @@
+# Use Case
+
+Some validation logic needs to be executed on click of a list banner button. The field values to be validated are present right on the screen, so why bother writing a GlideAjax code + client-callable Script Include to call the server and run the same validation on the server. Client-side ```GlideList``` API provides the ```getCell()``` method to fetch visible cell values from the list.
+
+
+# Usage
+
+Write a client-side code on the UI Action and add the code in ```script.js``` file.
+```g_list.getCell(String recSysId, String fieldName)```
+
+
+# Explanation
+
+Values of visible fields/cells can be extracted using the ```getCell(String recSysId, String fieldName)``` method of client-side class ```GlideList (g_list)```. Required parameters:
+  - ```String recSysId``` - SysID of the record/row whose value is to be fetched
+  - ```String fieldName``` - Name of the field whose value is to be fetched
+Returns: ```HTMLElement (HTMLTableCellElement)```, string content can be extracted using ```.innerText``` property

--- a/Client Scripts/Get Field Value From List on Client/README.md
+++ b/Client Scripts/Get Field Value From List on Client/README.md
@@ -1,6 +1,6 @@
 # Use Case
 
-Some validation logic needs to be executed on click of a list banner button. The field values to be validated are present right on the screen, so why bother writing a GlideAjax code + client-callable Script Include to call the server and run the same validation on the server. Client-side ```GlideList``` API provides the ```getCell()``` method to fetch visible cell values from the list.
+Let;s consider a scenario. Some validation logic needs to be executed on click of a list banner button. The field values to be validated are present right on the screen, so why bother writing a GlideAjax code + client-callable Script Include to call the server and run the same validation on the server. Client-side ```GlideList``` API provides the ```getCell()``` method to fetch visible cell values from the list.
 
 
 # Usage

--- a/Client Scripts/Get Field Value From List on Client/README.md
+++ b/Client Scripts/Get Field Value From List on Client/README.md
@@ -14,4 +14,5 @@ Write a client-side code on the UI Action and add the code in ```script.js``` fi
 Values of visible fields/cells can be extracted using the ```getCell(String recSysId, String fieldName)``` method of client-side class ```GlideList (g_list)```. Required parameters:
   - ```String recSysId``` - SysID of the record/row whose value is to be fetched
   - ```String fieldName``` - Name of the field whose value is to be fetched
-Returns: ```HTMLElement (HTMLTableCellElement)```, string content can be extracted using ```.innerText``` property
+
+**Returns:** ```HTMLElement (HTMLTableCellElement)```, string content can be extracted using ```.innerText``` property

--- a/Client Scripts/Get Field Value From List on Client/script.js
+++ b/Client Scripts/Get Field Value From List on Client/script.js
@@ -1,0 +1,15 @@
+/* g_list.getCell(rowSysId, <field_name>) - Accepts two parameters
+ * recordSysID (to identify the row) - For example: 23d7584c977a611056e8b3e6f053af6b
+ * field_name - name of the field whose value is to be fetched
+ */
+
+var recSysId = g_list.getChecked(); // 23d7584c977a611056e8b3e6f053af6b - Can be modified to pass Sys ID by other means
+var fieldName = 'short_description'; // Modify as per requirement
+
+var cellVal = g_list.getCell(recSysId, fieldName).innerText;
+
+g_GlideUI.addOutputMessage({
+    msg: cellVal,
+    type: 'success',
+    preventDuplicates: true
+}); // Using this fancy notification trick because g_form is not supported on list view


### PR DESCRIPTION
Values of visible fields/cells of a list row can be extracted using the ```getCell(String recSysId, String fieldName)``` method of client-side ```GlideList (g_list)``` class. This saves an unnecessary Ajax call to the server to fetch values that are present right on the screen. Required parameters:

- ```String recSysId``` - SysID of the record/row whose value is to be fetched
- ```String fieldName``` - Name of the field whose value is to be fetched

**Returns:** ```HTMLElement (HTMLTableCellElement)```, string content can be extracted using ```.innerText``` property