### PR TITLE
Create Close Parent if tasks are closed

### DIFF
--- a/Business Rules/Close Parent if tasks are closed
+++ b/Business Rules/Close Parent if tasks are closed
@@ -1,0 +1,23 @@
+Condition -(After Update) If child task state changes to CLOSED
+(function executeRule(current, previous /*null when async*/ ) {
+    var gr = new GlideRecord('TASK_TABLE_NAME');
+    gr.addQuery('parent', current.parent);
+    gr.addActiveQuery();
+    gr.query();
+    var count = gr.getRowCount(); // getting count of active tasks with the current parent
+    if (count == 0) // Checking whether the parent has no child tasks to update the parent case
+    {
+        var cse = new GlideRecord('PARENT_TABLE_NAME');
+        cse.addQuery('sys_id', current.parent);
+        cse.query();
+        if (cse.next()) {
+            cse.state = '3'; // Set case to Completed
+            cse.update();
+        }
+        gs.info("Parent Case is Automatically closed since all the child tasks are completed");
+    } else {
+			//do nothing
+    }
+
+
+})(current, previous);


### PR DESCRIPTION
In any custom table having parent-child relationships, the given script will run in a child table whenever all the child task states change to closed, it will automatically close the parent.