### PR TITLE
Stop closing Parent  when child tasks are not closed

### DIFF
--- a/Business Rules/Stop closing Parent  when child tasks are not closed
+++ b/Business Rules/Stop closing Parent  when child tasks are not closed
@@ -1,0 +1,15 @@
+Condition -(Before Update) Parent case state to CLOSED
+
+(function executeRule(current, previous /*null when async*/ ) {
+
+    var gr = new GlideRecord('TASK_TABLE NAME');
+    gr.addQuery('parent', current.sys_id);
+    gr.addQuery('state', '!=', 3);
+    gr.query();
+    if (gr.next()) {
+        gs.addErrorMessage('Cannot close Parent Case with open child Task');
+        current.state = previous.state;
+        current.setAbortAction(true); //abort the record
+    }
+
+})(current, previous);


### PR DESCRIPTION
This script will run in the parent table whenever any case is closed, check for child task states if any of them are open it restricts the closure of a parent.