### PR TITLE
Show message on form and list

### DIFF
--- a/Client Scripts/Show Message On Both Form and List/README.md
+++ b/Client Scripts/Show Message On Both Form and List/README.md
@@ -1,0 +1,57 @@
+# Use Case
+The OOB `GlideForm (g_form)` API has documentation on displaying messages of info, warning and error types on form view, but lack a success message. Moreover, this `g_form` API is not accessible on lists and hence makes it difficult to display list level messages.
+However, SN provides another client-side method `GlideUI.get().addOutputMessage({options})` that can be used to display messages in native UI irrespective of form or list views. Even the popular `g_form.addInfoMessage(params)` API actually leverages the same `addOutputMessage(options)` method to render messages.
+Custom icons can also be included, but the background colour is lost due to the way `.addOutputMessage()`  method has been implemented.
+
+Allowed icons (as per SN documentation): > icon-user, icon-user-group, icon-lightbulb, icon-home, icon-mobile, icon-comment, icon-mail, icon-locked, icon-database, icon-book, icon-drawer, icon-folder, icon-catalog, icon-tab, icon-cards, icon-tree-right, icon-tree, icon-book-open, icon-paperclip, icon-edit, icon-trash, icon-image, icon-search, icon-power, icon-cog, icon-star, icon-star-empty, icon-new-ticket, icon-dashboard, icon-cart-full, icon-view, icon-label, icon-filter, icon-calendar, icon-script, icon-add, icon-delete, icon-help, icon-info, icon-check-circle, icon-alert, icon-sort-ascending, icon-console, icon-list, icon-form, and icon-livefeed
+
+![image](https://github.com/annaydas/code-snippets/assets/29729050/7c93828c-d30a-4255-a97c-a2ee4f9126ac)
+
+
+# Usage
+
+### Success Message
+```
+GlideUI.get().addOutputMessage({
+    msg: 'Success',
+    type: 'success',
+    preventDuplicates: true
+});
+```
+
+### Warning Message
+```
+GlideUI.get().addOutputMessage({
+    msg: 'Warning',
+    type: 'warning',
+    preventDuplicates: true
+});
+```
+
+### Error Message
+```
+GlideUI.get().addOutputMessage({
+    msg: 'Error',
+    type: 'error',
+    preventDuplicates: true
+});
+```
+
+### Info Message
+```
+GlideUI.get().addOutputMessage({
+    msg: 'Info',
+    type: 'info',
+    preventDuplicates: true
+});
+```
+
+### Custom Icon (but it loses the background colour)
+```
+GlideUI.get().addOutputMessage({
+    msg: 'Custom Icon, but styling is lost',
+    icon: 'icon-lightbulb',
+    type: 'custom-message',
+    preventDuplicates: true
+});
+```

--- a/Client Scripts/Show Message On Both Form and List/README.md
+++ b/Client Scripts/Show Message On Both Form and List/README.md
@@ -3,7 +3,8 @@ The OOB `GlideForm (g_form)` API has documentation on displaying messages of inf
 However, SN provides another client-side method `GlideUI.get().addOutputMessage({options})` that can be used to display messages in native UI irrespective of form or list views. Even the popular `g_form.addInfoMessage(params)` API actually leverages the same `addOutputMessage(options)` method to render messages.
 Custom icons can also be included, but the background colour is lost due to the way `.addOutputMessage()`  method has been implemented.
 
-Allowed icons (as per SN documentation): > icon-user, icon-user-group, icon-lightbulb, icon-home, icon-mobile, icon-comment, icon-mail, icon-locked, icon-database, icon-book, icon-drawer, icon-folder, icon-catalog, icon-tab, icon-cards, icon-tree-right, icon-tree, icon-book-open, icon-paperclip, icon-edit, icon-trash, icon-image, icon-search, icon-power, icon-cog, icon-star, icon-star-empty, icon-new-ticket, icon-dashboard, icon-cart-full, icon-view, icon-label, icon-filter, icon-calendar, icon-script, icon-add, icon-delete, icon-help, icon-info, icon-check-circle, icon-alert, icon-sort-ascending, icon-console, icon-list, icon-form, and icon-livefeed
+**Allowed icons (as per SN documentation):**
+> icon-user, icon-user-group, icon-lightbulb, icon-home, icon-mobile, icon-comment, icon-mail, icon-locked, icon-database, icon-book, icon-drawer, icon-folder, icon-catalog, icon-tab, icon-cards, icon-tree-right, icon-tree, icon-book-open, icon-paperclip, icon-edit, icon-trash, icon-image, icon-search, icon-power, icon-cog, icon-star, icon-star-empty, icon-new-ticket, icon-dashboard, icon-cart-full, icon-view, icon-label, icon-filter, icon-calendar, icon-script, icon-add, icon-delete, icon-help, icon-info, icon-check-circle, icon-alert, icon-sort-ascending, icon-console, icon-list, icon-form, and icon-livefeed
 
 ![image](https://github.com/annaydas/code-snippets/assets/29729050/7c93828c-d30a-4255-a97c-a2ee4f9126ac)
 

--- a/Client Scripts/Show Message On Both Form and List/README.md
+++ b/Client Scripts/Show Message On Both Form and List/README.md
@@ -11,7 +11,7 @@ Allowed icons (as per SN documentation): > icon-user, icon-user-group, icon-ligh
 # Usage
 
 ### Success Message
-```
+```javascript
 GlideUI.get().addOutputMessage({
     msg: 'Success',
     type: 'success',
@@ -20,7 +20,7 @@ GlideUI.get().addOutputMessage({
 ```
 
 ### Warning Message
-```
+```javascript
 GlideUI.get().addOutputMessage({
     msg: 'Warning',
     type: 'warning',
@@ -29,7 +29,7 @@ GlideUI.get().addOutputMessage({
 ```
 
 ### Error Message
-```
+```javascript
 GlideUI.get().addOutputMessage({
     msg: 'Error',
     type: 'error',
@@ -38,7 +38,7 @@ GlideUI.get().addOutputMessage({
 ```
 
 ### Info Message
-```
+```javascript
 GlideUI.get().addOutputMessage({
     msg: 'Info',
     type: 'info',
@@ -47,7 +47,7 @@ GlideUI.get().addOutputMessage({
 ```
 
 ### Custom Icon (but it loses the background colour)
-```
+```javascript
 GlideUI.get().addOutputMessage({
     msg: 'Custom Icon, but styling is lost',
     icon: 'icon-lightbulb',

--- a/Client Scripts/Show Message On Both Form and List/README.md
+++ b/Client Scripts/Show Message On Both Form and List/README.md
@@ -6,6 +6,9 @@ Custom icons can also be included, but the background colour is lost due to the 
 **Allowed icons (as per SN documentation):**
 > icon-user, icon-user-group, icon-lightbulb, icon-home, icon-mobile, icon-comment, icon-mail, icon-locked, icon-database, icon-book, icon-drawer, icon-folder, icon-catalog, icon-tab, icon-cards, icon-tree-right, icon-tree, icon-book-open, icon-paperclip, icon-edit, icon-trash, icon-image, icon-search, icon-power, icon-cog, icon-star, icon-star-empty, icon-new-ticket, icon-dashboard, icon-cart-full, icon-view, icon-label, icon-filter, icon-calendar, icon-script, icon-add, icon-delete, icon-help, icon-info, icon-check-circle, icon-alert, icon-sort-ascending, icon-console, icon-list, icon-form, and icon-livefeed
 
+
+# Output Screenshot
+
 ![image](https://github.com/annaydas/code-snippets/assets/29729050/7c93828c-d30a-4255-a97c-a2ee4f9126ac)
 
 

--- a/Client Scripts/Show Message On Both Form and List/script.js
+++ b/Client Scripts/Show Message On Both Form and List/script.js
@@ -1,0 +1,27 @@
+// Success Message
+GlideUI.get().addOutputMessage({
+    msg: 'Success',
+    type: 'success',
+    preventDuplicates: true
+});
+
+// Warning Message
+GlideUI.get().addOutputMessage({
+    msg: 'Warning',
+    type: 'warning',
+    preventDuplicates: true
+});
+
+// Error Message
+GlideUI.get().addOutputMessage({
+    msg: 'Error',
+    type: 'error',
+    preventDuplicates: true
+});
+
+// Info Message
+GlideUI.get().addOutputMessage({
+    msg: 'Info',
+    type: 'info',
+    preventDuplicates: true
+});


### PR DESCRIPTION
This code snippet provides functionality to display messages on both form and list view in native UI. This extends capabilities of existing OOB client-side `GlideUI` Class to render the messages.

**Sample Code:**
```
GlideUI.get().addOutputMessage({
    msg: 'Success',
    type: 'warning',
    preventDuplicates: true
});
```
**Screenshot:**
![image](https://github.com/ServiceNowDevProgram/code-snippets/assets/29729050/f3d231c9-a8ef-49e7-b38c-240f78aaf75b)
