### PR TITLE
Read workspace url

### DIFF
--- a/Business Rules/Read Workspace URL/ReadWS_URL.js
+++ b/Business Rules/Read Workspace URL/ReadWS_URL.js
@@ -1,0 +1,37 @@
+(function executeRule(current, previous /*null when async*/) {
+	// for new record
+    if (current.isNewRecord()) {
+        // read the URL
+		var txn = GlideTransaction.get();
+		if (!txn)
+			return;
+		var request = txn.getRequest();
+		if (!request)
+			return;
+		var referer = decodeURIComponent(request.getHeader("Referer"));
+		
+		if (GlideStringUtil.nil(referer))
+			return;
+		// use regular expression to read the parameters from the referer - we just need the last group	
+		var matches = referer.match(/\/(agent|sow)\/(chat|record\/interaction)\/-1_uid_1\/params\/query\/(.*)/);
+		if (!matches || matches.length < 4)
+			return;		
+		// if there is no caller_id in the query parameters, dont do anything
+		if (matches[3].indexOf('caller_id') < 0)
+			return;
+		// parse the parameters and when encountering caller_id, get the user's unique identifier - in this case the email address - and set it in the scratchpad
+		var params = matches[3].split('^');
+		for (var i=0; i<params.length;i++) {
+			// the parameters are key=name value pairs
+			var param = params[i].split('=');			
+			if (param.length == 2 && param[0] == 'caller_id') {
+				var grUser = new GlideRecord('sys_user');
+				if (grUser.get('email', param[1])) {
+					g_scratchpad.caller_id = grUser.getUniqueValue();
+				}
+				return;
+			}
+		}
+	}
+})(current, previous);
+

--- a/Business Rules/Read Workspace URL/readme.md
+++ b/Business Rules/Read Workspace URL/readme.md
@@ -1,0 +1,7 @@
+Display BR that reads the caller_id parameter from the Workspace URL (agent or sow) for creating a new record/interaction and seearches 
+for the corresponding user to set it in the g_scratchpad to be used as default value in the new Interaction form. 
+eg url https://instance-name.service-now.com/now/sow/record/interaction/-1_uid_1/params/query/active%3Dtrue%5Ecaller_id=<email>
+
+The scratchpad can be used in an onLoad client script like so:
+   if (g_form.isNewRecord())
+		g_form.setValue('opened_for', g_scratchpad.caller_id);


### PR DESCRIPTION
Display Business Rule used to read a parameter from the sow or agent workspace URL. In this BR a parameter caller_id is read, which contains an email address. The email address is then used to find the appropriate user in the sys_user table, which then will be set in a scratchpad variable. This can be used for eg in an onLoad Client script to set the default value of a field.

![image](https://github.com/ServiceNowDevProgram/code-snippets/assets/32241359/045930fa-fb32-4c19-8f31-f9830a5b04b9)
