### PR TITLE
Toggle annotation on forms with script

### DIFF
--- a/Client Scripts/Toggle Annotation On Forms With Script/README.md
+++ b/Client Scripts/Toggle Annotation On Forms With Script/README.md
@@ -1,0 +1,26 @@
+# Use Case
+This method can be used to show/hide/toggle form annotations through client-side script.
+
+# Limitation
+This script works only with form annotations of the following types:
+- Info Box Blue
+- Info Box Red
+- Section Details
+- Text
+
+# Usage
+
+### Show form annotations
+```javascript
+SN.formAnnotations.show();
+```
+
+### Hide form annotations
+```javascript
+SN.formAnnotations.hide();
+```
+
+### Toggle form annotations
+```javascript
+SN.formAnnotations.toggle();
+```

--- a/Client Scripts/Toggle Annotation On Forms With Script/script.js
+++ b/Client Scripts/Toggle Annotation On Forms With Script/script.js
@@ -1,0 +1,8 @@
+// Show form annotations
+SN.formAnnotations.show();
+
+// Hide form annotations
+SN.formAnnotations.hide();
+
+// Toggle form annotations
+SN.formAnnotations.toggle();


### PR DESCRIPTION
This method can be used to show/hide/toggle form annotations through client-side script. This script works only with form annotations of the following types:
- Info Box Blue
- Info Box Red
- Section Details
- Text

### Show form annotations
```javascript
SN.formAnnotations.show();
```

### Hide form annotations
```javascript
SN.formAnnotations.hide();
```

### Toggle form annotations
```javascript
SN.formAnnotations.toggle();
```