### PR TITLE
Change update set application scope

### DIFF
--- a/Background Scripts/Change Update Set Application Scope/changeApplicationScope.js
+++ b/Background Scripts/Change Update Set Application Scope/changeApplicationScope.js
@@ -1,0 +1,27 @@
+function changeUpdateSetApplicationScope(updateSetName, currentApplicationScope, newApplicationScope) {
+
+    var newApplicationScopeSysId = getApplicationScopeSysId(newApplicationScope);
+
+    var updateSetGR = new GlideRecord("sys_update_set");
+    updateSetGR.addQuery('name', updateSetName);
+    updateSetGR.addQuery('application.name', currentApplicationScope);
+    updateSetGR.query();
+
+    if (updateSetGR.next()) {
+        updateSetGR.setValue('application', newApplicationScopeSysId);
+        updateSetGR.update();
+    }
+
+}
+
+function getApplicationScopeSysId(scopeName) {
+  
+    var appGR = new GlideRecord('sys_app');
+    appGR.addQuery('name', scopeName);
+    appGR.query();
+    if (appGR.next()) {
+        return appGR.getValue('sys_id');
+    }
+}
+
+changeUpdateSetApplicationScope('updateSetName', 'currentApplicationScope', 'newApplicationScope');

--- a/Background Scripts/Change Update Set Application Scope/readme.md
+++ b/Background Scripts/Change Update Set Application Scope/readme.md
@@ -1,0 +1,2 @@
+# Change update set application scope
+In ServiceNow, there are instances where an update set is mistakenly created in the incorrect application scope. To rectify this, I've developed a background script that facilitates the alteration of the update set's application scope to the appropriate one.


### PR DESCRIPTION
In ServiceNow, there are instances where an update set is mistakenly created in the incorrect application scope. To rectify this, I've developed a background script that facilitates the alteration of the update set's application scope to the appropriate one.