### PR TITLE
Create Business Rule.js

### DIFF
--- a/Business Rule.js
+++ b/Business Rule.js
@@ -1,0 +1,12 @@
+// Situation: Notify the assigned technician when a change request is assigned to them.
+
+(function executeRule(current, previous /*, g*/) {
+    if (current.assignment_group && current.assigned_to) {
+        var technician = current.assigned_to.getDisplayValue();
+        gs.eventQueue('change.assigned', current, technician);
+    }
+})(current, previous);
+
+//This business rule is triggered when a change request is assigned to a technician. It checks if both the assignment group and assigned technician are defined. If they are, it sends an event ('change.assigned') to notify the assigned technician about their new task. This event can trigger notifications or workflows to ensure the technician is aware of the assignment.
+
+//These business rules help automate and enforce specific actions and processes within the ServiceNow platform based on various situations or conditions.


### PR DESCRIPTION
This business rule is triggered when a change request is assigned to a technician. It checks if both the assignment group and assigned technician are defined. If they are, it sends an event ('change.assigned') to notify the assigned technician about their new task. This event can trigger notifications or workflows to ensure the technician is aware of the assignment.

These business rules help automate and enforce specific actions and processes within the ServiceNow platform based on various situations or conditions.