### PR TITLE
Create Auto-Assign Incident to Support Group.js

### DIFF
--- a/Auto-Assign Incident to Support Group.js
+++ b/Auto-Assign Incident to Support Group.js
@@ -1,0 +1,14 @@
+// Situation: When a new incident is created, automatically assign it to the appropriate support group based on the categorization.
+
+(function executeRule(current, previous /*, g*/) {
+    if (current.category == 'Hardware' && current.subcategory == 'Laptop') {
+        current.assignment_group = 'Hardware Support';
+    } else if (current.category == 'Software' && current.subcategory == 'Application Issue') {
+        current.assignment_group = 'Software Support';
+    }
+})(current, previous);
+
+
+/*Explanation: This business rule is triggered when a new incident is created. It checks 
+the incident's category and subcategory and assigns it to the relevant support group based
+  on the categorization. For example, if the incident is related to a hardware issue with a laptop, it assigns the incident to the "Hardware Support" group.*/


### PR DESCRIPTION
 This business rule is triggered when a new incident is created. It checks the incident's category and subcategory and assigns it to the relevant support group based on the categorization. For example, if the incident is related to a hardware issue with a laptop, it assigns the incident to the "Hardware Support" group.