### PR TITLE
feat: new function returns variables as string

### DIFF
--- a/Script Includes/CatalogUtils/CatalogUtils.js
+++ b/Script Includes/CatalogUtils/CatalogUtils.js
@@ -9,22 +9,22 @@ var CatalogUtils = Class.create();
  */
 CatalogUtils.prototype = Object.extendsObject(global.AbstractAjaxProcessor, {
     /**
-	 * Returns all variables of a given RITM as stringified array of JSON objectss.
-	 *
-	 * @param {Object} objParameter Valid `sc_req_item` record or String-based Sys ID of a RITM.
-	 * @return {String} Stringified array of JSON objects with various variable values and information or an empty array if no valid data could be found.
-	 */
+     * Returns all variables of a given RITM as stringified array of JSON objectss.
+     *
+     * @param {Object} objParameter Valid `sc_req_item` record or String-based Sys ID of a RITM.
+     * @return {String} Stringified array of JSON objects with various variable values and information or an empty array if no valid data could be found.
+     */
     getVariables: function(objParameter) {
         var _grRITM = null;
 
         //server-side call with Sys ID
         if (typeof objParameter == 'string' && objParameter.length == 32) {
             _grRITM = new GlideRecord('sc_req_item');
-            
+
             if (!_grRITM.get(objParameter)) {
                 _grRITM = null;
             } 
-		    }
+        }
 
         //server-side call with initialized RITM GlideRecord 
         if (typeof objParameter == 'object' && objParameter instanceof GlideRecord) {
@@ -39,7 +39,7 @@ CatalogUtils.prototype = Object.extendsObject(global.AbstractAjaxProcessor, {
 
             if (_strSysID.length == 32) {
                 _grRITM = new GlideRecord('sc_req_item');
-            
+
                 if (!_grRITM.get(_strSysID)) {
                     _grRITM = null;
                 }
@@ -81,6 +81,25 @@ CatalogUtils.prototype = Object.extendsObject(global.AbstractAjaxProcessor, {
         }
 
         return JSON.stringify(_arrResult);
+    },
+
+    /**SNDOC
+    @name _variablesToText
+    @description Parses over the variables of a given record, returning Question Label and Display Value of answers
+    @param {object} [pRecord] GlideRecord object with variables key
+    @returns {string} A formatted string of variable questions and corresponding answer
+    */
+    variablesToText: function (pRecord) {
+        var oVariables = pRecord.variables;
+        var aPayload = [];
+        for (key in oVariables) {
+            var sQuestion = oVariables[key].getLabel();
+            var sAnswer = oVariables[key].getDisplayValue();
+            if (JSUtil.notNil(sQuestion) && JSUtil.notNil(sAnswer)) {
+                aPayload.push(sQuestion + ':\n>>' + sAnswer);
+            }
+        }
+        return aPayload.join('\n\n');
     },
 
     type: 'CatalogUtils',

--- a/Script Includes/CatalogUtils/readme.md
+++ b/Script Includes/CatalogUtils/readme.md
@@ -51,3 +51,33 @@ var jsonVariables = JSON.parse(gaCatalogUtils.getAnswer() || "");
   }
 ]
 ```
+
+## Variables to Text
+
+Returns all Variables with an answer as a formatted string.
+Useful for 'exporting' question:answers to primitive fields such as description or notifications 
+Expected use is Server side.
+
+### Example of server-side call
+```javascript
+var grRITM = new GlideRecord('sc_req_item');
+
+if (grRITM.get('8c135e0647b1b110da816241e36d437e')) {
+    var jsonVariables = JSON.parse((new CatalogUtils()).variablesToText(grRITM));
+}
+```
+
+### Example of returned values
+```
+Copier paper (reams):
+>>3
+
+Pens (box of 10):
+>>3
+
+Screen wipes (tube of 20):
+>>4
+
+Additional requirements:
+>>I need this yesterday
+```


### PR DESCRIPTION
variablesToText checks record variables & returns Question & answer to string.
Returns all Variables with an answer as a formatted string. 
Can be used to apply question:answers to string fields or notifications

Added to CatalogUtils,this Script include has similar functionality.
Included example use and example output as per existing template.

Formatting updates to Script Include.