### PR TITLE
Preview context record during approval

### DIFF
--- a/UI Actions/Preview context record during approval/README.md
+++ b/UI Actions/Preview context record during approval/README.md
@@ -1,0 +1,1 @@
+While approving any request it was very hard until now to preview the record for which the approval was required. This UI action created on sysapproval_approver table will enable previewing the record before approval so that the approver can make an easy informed decision.

--- a/UI Actions/Preview context record during approval/TestScriptInclude.js
+++ b/UI Actions/Preview context record during approval/TestScriptInclude.js
@@ -1,0 +1,17 @@
+var TestScriptInclude = Class.create();
+TestScriptInclude.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+
+	getDocumentClass: function(){
+		var sysId = this.getParameter("sysparm_sys_id");
+		var gr = new GlideRecord("sysapproval_approver");
+		if(gr.get(sysId)){
+			return JSON.stringify({
+				"table": gr.source_table.toString(),
+				"document": gr.document_id.toString(),
+				"title": gr.document_id.getDisplayValue()
+			});
+		}
+	},
+
+    type: 'TestScriptInclude'
+});

--- a/UI Actions/Preview context record during approval/UI_Action.js
+++ b/UI Actions/Preview context record during approval/UI_Action.js
@@ -1,0 +1,18 @@
+/*
+This script should be placed in the UI action on the table sysapproval_approver.
+This UI action should be marked as client callable script include.
+Use openContextRecord() function in the Onclick field.
+*/
+
+function openContextRecord() {
+    var rec = g_form.getDisplayValue("document_id");
+    var gaSi = new GlideAjax("TestScriptInclude");
+    gaSi.addParam("sysparm_name", "getDocumentClass");
+    gaSi.addParam("sysparm_sys_id", g_form.getUniqueValue());
+    gaSi.getXMLAnswer(function(response) {
+        var answer = JSON.parse(response);
+        var gp = new GlideModalForm(answer.title, answer.table, function(){});
+        gp.addParm('sys_id', answer.document);
+        gp.render();
+    });
+}


### PR DESCRIPTION
While approving any request it was very hard until now to preview the record for which the approval was required. This UI action created on sysapproval_approver table will enable previewing the record before approval so that the approver can make an easy informed decision.