### PR TITLE
How to adjust the Date format within a client script to align with the User Date format

### DIFF
--- a/Client Scripts/How to adjust the Date format within a client script to align with the User Date format/code.js
+++ b/Client Scripts/How to adjust the Date format within a client script to align with the User Date format/code.js
@@ -1,0 +1,2 @@
+var currentDateObj = new Date();
+var currentDateUsr = formatDate(currentDateObj, g_user_date_format);

--- a/Client Scripts/How to adjust the Date format within a client script to align with the User Date format/readme.md
+++ b/Client Scripts/How to adjust the Date format within a client script to align with the User Date format/readme.md
@@ -1,0 +1,11 @@
+# When getting a date from another table, it's usually in the format (YYYY-MM-DD). To display it in the user's preferred format on the client side, use the method below.
+
+ If date is fetched from a query(like GlideAjax), date returned from query pass that date object into "new Date()"
+
+# Example
+ ```
+var user_date = formatDate(new Date(<returnDateObj>), g_user_date_format)
+
+g_form.setValue('<field_name>',user_date);
+
+```

--- a/Fix scripts/Run Subscription Job On Demand/code.js
+++ b/Fix scripts/Run Subscription Job On Demand/code.js
@@ -1,0 +1,2 @@
+var summarizer = new SNC.SubscriptionSummarizer();
+summarizer.runSummary();

--- a/Fix scripts/Run Subscription Job On Demand/readme.md
+++ b/Fix scripts/Run Subscription Job On Demand/readme.md
@@ -1,0 +1,7 @@
+# Usage
+If you wish to update/re-calculate your allocated entitlements on the subscription management dashboard, execute the following two lines of code. You can run this server script either in the background script or maintain it as a fix script and run it on-demand.
+
+```
+var summarizer = new SNC.SubscriptionSummarizer();
+		             summarizer.runSummary();
+```


### PR DESCRIPTION
I added a folder: How to adjust the Date format within a client script to align with the User Date format, code.js, and readme.md.



