### PR TITLE
Fix security issues

### DIFF
--- a/GlideAjax/Reusable GlideAjax/clientCallableScriptInclude.js
+++ b/GlideAjax/Reusable GlideAjax/clientCallableScriptInclude.js
@@ -6,7 +6,7 @@ ScriptIncludeName.prototype = Object.extendsObject(AbstractAjaxProcessor, {
         var query = this.getParameter('sysparm_query');
         var columns = this.getParameter('sysparm_returnAttributes').split(',');
         if (tableName != '') {
-            var grObj = new GlideRecord(tableName);
+            var grObj = new GlideRecordSecure(tableName);
             grObj.addEncodedQuery(query);
             grObj.setLimit(1);
             grObj.query();

--- a/GlideAjax/Reusable glideajax table query/getTableColumnsClientSide.js
+++ b/GlideAjax/Reusable glideajax table query/getTableColumnsClientSide.js
@@ -11,7 +11,7 @@ getTableColumnsClientSide.prototype = Object.extendsObject(AbstractAjaxProcessor
         }
         var returnData = [];
         var mappCol = columns.split(',');
-        var fetchColumn = new GlideRecord(tableName);
+        var fetchColumn = new GlideRecordSecure(tableName);
         fetchColumn.addEncodedQuery(encodedQuery);
         fetchColumn.setLimit(1); //Fetch only one record {Check the Query if it return wrong data}
         fetchColumn.query();

--- a/Script Includes/Collect Field Values from Any One Table Record/universalRecordCollector.js
+++ b/Script Includes/Collect Field Values from Any One Table Record/universalRecordCollector.js
@@ -8,7 +8,7 @@ DV_Record_Details.prototype = Object.extendsObject(AbstractAjaxProcessor, {
 		
 	var fields = fieldNames.split(',');
 		
-        var targetRecord = new GlideRecord(table);
+        var targetRecord = new GlideRecordSecure(table);
         targetRecord.addQuery('sys_id', recordID);
         targetRecord.query();
 

--- a/Script Includes/GlideRecordHelper/script.js
+++ b/Script Includes/GlideRecordHelper/script.js
@@ -61,7 +61,7 @@ GlideRecordHelper.prototype = Object.extendsObject(AbstractAjaxProcessor, {
 	},
 
 	getFieldsObjectWithQuery: function(table,query,values){
-		var gr = new GlideRecord(table);
+		var gr = new GlideRecordSecure(table);
 		gr.addEncodedQuery(query);
 		gr.query();
 
@@ -103,7 +103,7 @@ GlideRecordHelper.prototype = Object.extendsObject(AbstractAjaxProcessor, {
 
 	getFieldsMultiObjectWithQuery: function(table,query,values){
 		var fieldObjectArray = [];
-		var gr = new GlideRecord(table);
+		var gr = new GlideRecordSecure(table);
 		gr.addEncodedQuery(query);
 		gr.query();
 		while(gr.next()){
@@ -123,7 +123,7 @@ GlideRecordHelper.prototype = Object.extendsObject(AbstractAjaxProcessor, {
 		table = table || this.getParameter('sysparm_table');
 		query = query || this.getParameter('sysparm_query');
 		var returnVar = false;
-		var grGlideRecord = new GlideRecord(table);
+		var grGlideRecord = new GlideRecordSecure(table);
 		grGlideRecord.addEncodedQuery(query);
 		grGlideRecord.query();
 		if (grGlideRecord.hasNext()) {

--- a/Script Includes/Table List Copy Context Options/Script Include.js
+++ b/Script Includes/Table List Copy Context Options/Script Include.js
@@ -6,7 +6,7 @@ ListCopyOptions.prototype = Object.extendsObject(AbstractAjaxProcessor, {
 		var sys_id = this.getParameter('sysparm_sys_id');
 		var field = this.getParameter('sysparm_field');
 		var table = this.getParameter('sysparm_table');
-		var this_gr = new GlideRecord(table);
+		var this_gr = new GlideRecordSecure(table);
 		this_gr.get(sys_id);
 		return this_gr.getDisplayValue(field);
 	},

--- a/UI Actions/Mark Records Inactive - List Action/scriptInclude.js
+++ b/UI Actions/Mark Records Inactive - List Action/scriptInclude.js
@@ -5,7 +5,7 @@ MarkRecordsInactive.prototype = Object.extendsObject(AbstractAjaxProcessor, {
         var sysIds = this.getParameter('sysparm_ids');
         var tableName = this.getParameter('sysparm_table');
         
-		var recs = new GlideRecord(tableName);
+		var recs = new GlideRecordSecure(tableName);
 		recs.addEncodedQuery('sys_idIN'+sysIds);
 		recs.query();
 		while(recs.next())


### PR DESCRIPTION
The updated client-callable Script Includes are vulnerable and allow an attacker to bypass the ACLs. We should avoid such examples in the repository since not all developers understand the consequences of using "generic" `GlideAjax` for retrieving data using the `GlideRecord`.