### PR TITLE
Get active mid servers

### DIFF
--- a/Background Scripts/Get Active MID Servers/GetActiveMidServer.js
+++ b/Background Scripts/Get Active MID Servers/GetActiveMidServer.js
@@ -1,0 +1,25 @@
+/**
+ * Retrieves the name of an active MID Server that is both up and validated.
+ * @returns {string|null} The name of the active MID Server, or null if none is found.
+ */
+function getActiveMidServer() {
+    // Create a GlideRecord object for the 'ecc_agent' table
+    var grServer = new GlideRecord('ecc_agent');
+
+    // Add an encoded query to filter for MID Servers that are up and validated
+    grServer.addEncodedQuery('status=Up^validated=true');
+
+    // Execute the query
+    grServer.query();
+
+    // Check if a record matching the query criteria was found
+    if (grServer.next()) {
+        // Return the name of the active MID Server
+        return grServer.name;
+    } else {
+        // No active MID Server found, return null
+        return null;
+    }
+}
+
+getActiveMidServer();

--- a/Background Scripts/Get Active MID Servers/readme.md
+++ b/Background Scripts/Get Active MID Servers/readme.md
@@ -1,0 +1,4 @@
+# ServiceNow Script: getActiveMidServer
+
+## Description
+This ServiceNow script defines a function, `getActiveMidServer`, that retrieves the name of an active MID Server that is both up and validated. MID Servers are essential components in the ServiceNow platform for various integration and automation tasks.


### PR DESCRIPTION
ServiceNow script defines a function, `getActiveMidServer`, that retrieves the name of an active MID Server that is both up and validated. MID Servers are essential components in the ServiceNow platform for various integration and automation tasks.