### PR TITLE
Look up Support group of CI

### DIFF
--- a/Flow Actions/Look up Support group of CI/LookUpSupportGroupFromCI.js
+++ b/Flow Actions/Look up Support group of CI/LookUpSupportGroupFromCI.js
@@ -1,0 +1,15 @@
+(function execute(inputs, outputs) {
+  
+  // Be sure to update inputs variable for Configuration Item
+  var supportGroup = inputs.configuration_item.support_group;
+  var answer = '';
+
+  if (supportGroup == '') {
+    answer = inputs.default_support_group; //Return the group specified in the "Default support group" input
+  } else {
+    answer = supportGroup; //Return the 'Support group' specified on the CI input
+  }
+
+  outputs.support_group = answer;
+
+})(inputs, outputs);

--- a/Flow Actions/Look up Support group of CI/readme.md
+++ b/Flow Actions/Look up Support group of CI/readme.md
@@ -1,0 +1,11 @@
+## Overview
+To be used within an action to retrieve the **Support group** of a specified CI.  If specified CI does not have a **Support group** a default value can be provided to return
+
+## Inputs
+Pass in the Configuration Item record and specify a **Support group** to return if the provided CI does not have a **Support group** populated
+
+## Script Step
+Create a script step with the code provided to look up the CI's **Support group** and return the appropriate value
+
+## Outputs
+Returns a group


### PR DESCRIPTION
An action to return the **Support group** of a given CI or return a default group (specified as an input) if there is no **Support group** value on the specified CI. 