### PR TITLE
Create Replace HTML tags using script to get the actual text

### DIFF
--- a/Background Scripts/Replace HTML tags using script to get the actual text
+++ b/Background Scripts/Replace HTML tags using script to get the actual text
@@ -1,5 +1,8 @@
 function replaceHtmlTags(inputString) {
     // Use regular expression to match HTML tags and replace them with an empty string
+ if (typeof inputString !== 'string') {
+    throw new Error('Input must be a string');
+  }
     var regex = /<(?:.|\n)*?>/gm;
     return inputString.replace(regex, '');
 }

--- a/Background Scripts/Replace HTML tags using script to get the actual text
+++ b/Background Scripts/Replace HTML tags using script to get the actual text
@@ -1,0 +1,11 @@
+function replaceHtmlTags(inputString) {
+    // Use regular expression to match HTML tags and replace them with an empty string
+    var regex = /<(?:.|\n)*?>/gm;
+    return inputString.replace(regex, '');
+}
+
+// Example usage:
+var originalString = '<p>This is a <b>sample</b> text with <a href="https://example.com">links</a>.</p>';
+var stringWithoutHtmlTags = replaceHtmlTags(originalString);
+gs.info('Original String: ' + originalString);
+gs.info('String without HTML tags: ' + stringWithoutHtmlTags);


### PR DESCRIPTION
This is useful for extracting text from HTML strings.

Removes HTML tags from an input string using regular expressions. It replaces all HTML tags with an empty string, leaving only the plain text content.