### PR TITLE
GlideRecordUtils getFields 

### DIFF
--- a/GlideRecordUtil/Get Fields From GlideRecord/getFields.js
+++ b/GlideRecordUtil/Get Fields From GlideRecord/getFields.js
@@ -1,0 +1,19 @@
+/**
+ * getFields - Returns an array of all the fields in the specified GlideRecord.
+ * 
+ * Note: If there is a field name that is the same as the table name, the getFields() method does not return the value of the field.
+ * 
+ * @function
+ * @param {GlideRecord} gr - GlideRecord instance positioned to a valid record.
+ * @returns {Array} - Field names for the specified GlideRecord.
+**/
+
+var queryString = "<Encoded query to filter the record>";
+var now_GR = new GlideRecord('<table_name>');
+now_GR.addEncodedQuery(queryString);
+now_GR.query();
+now_GR.next();
+
+var gRU = new GlideRecordUtil();
+var fieldList = gRU.getFields(now_GR);
+gs.info(fieldList); // Output: Array of field names for the specified GlideRecord.

--- a/GlideRecordUtil/Get Fields From GlideRecord/readme.md
+++ b/GlideRecordUtil/Get Fields From GlideRecord/readme.md
@@ -1,0 +1,12 @@
+The code snippet provided is a JavaScript function that retrieves and logs the field names from a specified GlideRecord. The function getFields takes a GlideRecord instance as a parameter and returns an array containing the names of all the fields in the specified record.
+
+Functionality
+  getFields(gr: GlideRecord): Array
+  Purpose:
+    - Returns an array of all the fields in the specified GlideRecord.
+  Parameters:
+    - gr (GlideRecord): A GlideRecord instance positioned to a valid record.
+  Returns:
+    - An array of strings representing the field names in the specified GlideRecord.
+  Note:
+    - If there is a field name which is the same as the table name, the getFields() method does not return the value of the field.


### PR DESCRIPTION
The code snippet provided is a JavaScript function that retrieves and logs the field names from a specified GlideRecord using GlideRecordUtils API. The function getFields takes a GlideRecord instance as a parameter and returns an array containing the names of all the fields in the specified record.