### PR TITLE
Add work notes for SLA

### DIFF
--- a/Business Rules/Add woknotes for 75 percent SLA/addWorknotesForSLA.js
+++ b/Business Rules/Add woknotes for 75 percent SLA/addWorknotesForSLA.js
@@ -1,0 +1,18 @@
+(function executeRule(current, previous /*null when async*/) {
+
+	var getTaskSLA = new GlideRecord('task_sla');
+	//get the task SLA Record
+	getTaskSLA.addQuery('sys_id', current.event.instance);
+	getTaskSLA.query();
+	while(getTaskSLA.next()){
+		var incRec = new GlideRecord('incident');
+		//Hardware Group sysID - 8a5055c9c61122780043563ef53438e3
+		incRec.addEncodedQuery("active=true^sys_id=8a5055c9c61122780043563ef53438e3");
+		incRec.addQuery('sys_id', getTaskSLA.task);
+		incRec.query();
+		while(incRec.next()){
+			incRec.work_notes = "This ticket" + incRec.number +" has exceeded 75% of SLA.";
+			incRec.update();
+		}
+	}
+})(current, previous);

--- a/Business Rules/Add woknotes for 75 percent SLA/readme.md
+++ b/Business Rules/Add woknotes for 75 percent SLA/readme.md
@@ -1,0 +1,8 @@
+This business rule will run on the [sys_email_log] table.
+When to run: after, insert
+Filter condition: Notification is [select the notification]
+
+In the Advance> script> paste the code part.
+
+This business rule will help to provide exceeded time information as a UI 
+about the SLA in the worknotes of the ticket when it has been reached to certain time period(here it is 75%).


### PR DESCRIPTION
This rule will help to add work notes when SLA has reached a certain stage(end stage preferred).

This will help the assignee/manager to understand how much time has been spent or left in the SLA just by checking the worknotes as it will send an alert when SLA has reached 75% in this case.