### PR TITLE
Update worknotes

### DIFF
--- a/Business Rules/Update worknotes of Ptask to parent Problem record/readme.md
+++ b/Business Rules/Update worknotes of Ptask to parent Problem record/readme.md
@@ -1,0 +1,2 @@
+If user update work notes of problem task then it should update the same worknotes in parent problem record as well with highlighting problem task number.
+this business rule run after updation when worknote changes.

--- a/Business Rules/Update worknotes of Ptask to parent Problem record/script.js
+++ b/Business Rules/Update worknotes of Ptask to parent Problem record/script.js
@@ -1,0 +1,12 @@
+(function executeRule(current, previous /*null when async*/) {
+
+	var workNotes = current.work_notes.getJournalEntry(1);
+
+	var gr = new GlideRecord('problem');
+	gr.addQuery('sys_id',current.problem);
+	gr.query();
+	if(gr.next()){
+		gr.work_notes ='This worknote is updated in' + current.number + "\n" + workNotes;
+	}
+	gr.update();
+})(current, previous);


### PR DESCRIPTION
i have created a business rule that check if user update work notes of problem task then it should update the same worknotes in parent problem record as well with highlighting problem task number.