### PR TITLE
Bulk cat item image update

### DIFF
--- a/Fix scripts/Bulk Catalog Item Image Update/bulk-cat-item-image-update.js
+++ b/Fix scripts/Bulk Catalog Item Image Update/bulk-cat-item-image-update.js
@@ -1,0 +1,52 @@
+var table = 'sc_cat_item';
+var iconSysId = 'f1dd1def1ba9fd1086a098e7b04bcb81'; // sys_id of icon file
+var pictureSysId = 'f1dd1def1ba9fd1086a098e7b04bcb81'; // sys_id of picture file
+var query = 'category=6a6ab100dbd5cc10ee115d87f49619fb^active!=true'; // query used to identify items
+
+var grItem = new GlideRecord(table);
+grItem.addEncodedQuery(query);
+grItem.query();
+while (grItem.next()) {
+    createImage(pictureSysId, 'picture', table, grItem.sys_id);
+    createImage(iconSysId, 'icon', table, grItem.sys_id);
+}
+
+function createImage(attachmentID, fieldName, tableName, tableID) {
+
+    var attachmentGR = new GlideRecord('sys_attachment');
+    attachmentGR.get(attachmentID);
+    var fields = attachmentGR.getFields();
+    var imageGR = new GlideRecord('sys_attachment');
+    imageGR.initialize();
+    imageGR.compressed = attachmentGR.compressed;
+    imageGR.content_type = 'image/png';
+    imageGR.size_bites = attachmentGR.size_bites;
+    imageGR.size_compressed = attachmentGR.size_compressed;
+    imageGR.file_name = fieldName;
+    imageGR.table_name = 'ZZ_YY' + tableName;
+    imageGR.table_sys_id = tableID;
+    imageGR.state = '2';
+    var imageID = imageGR.insert();
+
+    copyAttachmentContent(attachmentID, imageID);
+
+}
+
+/*
+ oldID: sys_id of existing attachment
+ newID: sys_id of newly created attachment
+ */
+function copyAttachmentContent(oldID, newID) {
+    var oldGR = new GlideRecord('sys_attachment_doc');
+    oldGR.addQuery('sys_attachment', oldID);
+    oldGR.query();
+    while (oldGR.next()) {
+        var newGR = new GlideRecord('sys_attachment_doc');
+        newGR.initialize();
+        newGR.data = oldGR.data;
+        newGR.length = oldGR.length;
+        newGR.position = oldGR.position;
+        newGR.sys_attachment = newID;
+        newGR.insert();
+    }
+}

--- a/Fix scripts/Bulk Catalog Item Image Update/readme.md
+++ b/Fix scripts/Bulk Catalog Item Image Update/readme.md
@@ -1,0 +1,36 @@
+# Bulk Catalog Item Image Change
+
+Updates the image(s) associated with catalog items or record producers
+
+## Description
+
+This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers.
+
+## Getting Started
+
+### Dependencies
+
+* Must be in the Global scope.
+* The image being used must already exist in the db_image table.
+
+### Execution
+
+* Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
+* Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
+* Update the script variables as follows:
+** table = the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
+** iconSysId = the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
+** pictureSysId = the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
+** query = the encoded query you will use to identify the items to be updated
+* Run the script and the picture and/or icon fields will be updated
+
+## Authors
+
+Brad Warman
+
+https://www.servicenow.com/community/user/viewprofilepage/user-id/80167
+
+## Version History
+
+* 0.1
+    * Initial Release

--- a/Fix scripts/Bulk Catalog Item Image Update/readme.md
+++ b/Fix scripts/Bulk Catalog Item Image Update/readme.md
@@ -15,14 +15,14 @@ This script can perform bulk updates of the picture and/or icon fields used in c
 
 ### Execution
 
-* Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
-* Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
-* Update the script variables as follows:
-** table = the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
-** iconSysId = the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
-** pictureSysId = the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
-** query = the encoded query you will use to identify the items to be updated
-* Run the script and the picture and/or icon fields will be updated
+1. Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
+2. Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
+3. Update the script variables as follows:
+    * **table**: the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
+    * **iconSysId**: the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
+    * **pictureSysId**: the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
+    * **query**: the encoded query you will use to identify the items to be updated
+4. Run the script and the picture and/or icon fields will be updated
 
 ## Authors
 

--- a/Fix scripts/Bulk Catalog Item Image Update/readme.md
+++ b/Fix scripts/Bulk Catalog Item Image Update/readme.md
@@ -18,10 +18,10 @@ This script can perform bulk updates of the picture and/or icon fields used in c
 1. Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
 2. Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
 3. Update the script variables as follows:
-    * **table**: the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
-    * **iconSysId**: the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
-    * **pictureSysId**: the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
-    * **query**: the encoded query you will use to identify the items to be updated
+   * **table**: the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
+   * **iconSysId**: the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
+   * **pictureSysId**: the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
+   * **query**: the encoded query you will use to identify the items to be updated
 4. Run the script and the picture and/or icon fields will be updated
 
 ## Authors

--- a/Fix scripts/Calculate Business Duration/Readme.md
+++ b/Fix scripts/Calculate Business Duration/Readme.md
@@ -1,0 +1,1 @@
+Use this script to update the business duration field for records. Add the sys_id of a schedule in the selectedSchedule variable to factor in a schedule in the calculation. Table can be selected by using the table variable.

--- a/Fix scripts/Calculate Business Duration/calculate-business-duration.js
+++ b/Fix scripts/Calculate Business Duration/calculate-business-duration.js
@@ -1,0 +1,25 @@
+// This script will retrospectively calculate the business duration of records and update the business_duration field with the correct value.
+
+var selectedSchedule = ''; // Set the sys_id of the schedule you'd like to use to calculate duration
+table = 'sc_req_item'; // Change this to set a different table such as incident
+
+var gr = new GlideRecord(table);
+gr.addEncodedQuery("stateIN3,4^sys_created_on>javascript:gs.dateGenerate('2022-01-01','23:59:59')"); // Set your encoded query to whatever you would like
+gr.query();
+var count = 0;
+while (gr.next()) {
+    var startDate = new GlideDateTime(gr.sys_created_on);
+    var endDate = new GlideDateTime(gr.closed_at);
+    var schedule = new GlideSchedule();
+    schedule.load(selectedSchedule); 
+    var duration = schedule.duration(startDate, endDate);
+    gr.setValue('business_duration', duration);
+    var opened = gr.sys_created_on.getDisplayValue();
+    var resolved = gr.closed_at.getDisplayValue();
+    gr.setValue('calendar_duration', gs.dateDiff(opened, resolved, false));
+    gr.setWorkflow('false'); // Set to true if you want workflows to run
+    gr.autoSysFields('false'); // Set to true if you want system fields to be updated
+    gr.update();
+    count = count + 1;
+}
+gs.info(count + " records updated with new business duration value");


### PR DESCRIPTION
This script allows a user to update the picture and/or icon fields in catalog items in bulk. This can be used for scenarios where the same icon needs to be used for multiple existing catalog items, eg. all Apple related catalog items need to have their icons updated to a different colour Apple icon.