### PR TITLE
preventing catalog task state to close from list edit 

### DIFF
--- a/Catalog Client Script/onCellEdit Catalog Task State Change Restriction/readme.md
+++ b/Catalog Client Script/onCellEdit Catalog Task State Change Restriction/readme.md
@@ -1,0 +1,4 @@
+# Catalog Task state should not be closed from list edit
+The onCellEdit Client Script type is used for lists rather than forms and here 
+it is being used so that the task should not be closed from the list edit without
+opening the form and filling other mandatory details like worknotes etc.

--- a/Catalog Client Script/onCellEdit Catalog Task State Change Restriction/script.js
+++ b/Catalog Client Script/onCellEdit Catalog Task State Change Restriction/script.js
@@ -1,0 +1,10 @@
+function onCellEdit(sysIDs, table, oldValues, newValue, callback) {
+  var saveAndClose = true;
+ //Type appropriate comment here, and begin script below
+  // here the values are 7|closed skipped, 3|closed complete and 4|closed incomplete
+ if(newValue == 7 || newValue == 3 || newValue == 4) {
+	saveAndClose = false;
+	alert('you cannot update from list');
+ }
+ callback(saveAndClose); 
+}


### PR DESCRIPTION
This onCellEdit script is to prevent  changing state of catalog task from being closed in list edit. It checks the newValue and alerts the user if the value is 7, 3, or 4, by setting saveAndClose to false, then state cannot be changed.
Thankyou