### PR TITLE
Bulk update catalog item images

### DIFF
--- a/Fix scripts/Bulk Update Catalog Item Images/bulk-cat-item-image-update.js
+++ b/Fix scripts/Bulk Update Catalog Item Images/bulk-cat-item-image-update.js
@@ -1,0 +1,52 @@
+var table = 'sc_cat_item';
+var iconSysId = 'f1dd1def1ba9fd1086a098e7b04bcb81'; // sys_id of icon file
+var pictureSysId = 'f1dd1def1ba9fd1086a098e7b04bcb81'; // sys_id of picture file
+var query = 'category=6a6ab100dbd5cc10ee115d87f49619fb^active!=true'; // query used to identify items
+
+var grItem = new GlideRecord(table);
+grItem.addEncodedQuery(query);
+grItem.query();
+while (grItem.next()) {
+    createImage(pictureSysId, 'picture', table, grItem.sys_id);
+    createImage(iconSysId, 'icon', table, grItem.sys_id);
+}
+
+function createImage(attachmentID, fieldName, tableName, tableID) {
+
+    var attachmentGR = new GlideRecord('sys_attachment');
+    attachmentGR.get(attachmentID);
+    var fields = attachmentGR.getFields();
+    var imageGR = new GlideRecord('sys_attachment');
+    imageGR.initialize();
+    imageGR.compressed = attachmentGR.compressed;
+    imageGR.content_type = 'image/png';
+    imageGR.size_bites = attachmentGR.size_bites;
+    imageGR.size_compressed = attachmentGR.size_compressed;
+    imageGR.file_name = fieldName;
+    imageGR.table_name = 'ZZ_YY' + tableName;
+    imageGR.table_sys_id = tableID;
+    imageGR.state = '2';
+    var imageID = imageGR.insert();
+
+    copyAttachmentContent(attachmentID, imageID);
+
+}
+
+/*
+ oldID: sys_id of existing attachment
+ newID: sys_id of newly created attachment
+ */
+function copyAttachmentContent(oldID, newID) {
+    var oldGR = new GlideRecord('sys_attachment_doc');
+    oldGR.addQuery('sys_attachment', oldID);
+    oldGR.query();
+    while (oldGR.next()) {
+        var newGR = new GlideRecord('sys_attachment_doc');
+        newGR.initialize();
+        newGR.data = oldGR.data;
+        newGR.length = oldGR.length;
+        newGR.position = oldGR.position;
+        newGR.sys_attachment = newID;
+        newGR.insert();
+    }
+}

--- a/Fix scripts/Bulk Update Catalog Item Images/readme.md
+++ b/Fix scripts/Bulk Update Catalog Item Images/readme.md
@@ -4,7 +4,8 @@ Updates the image(s) associated with catalog items or record producers
 
 ## Description
 
-This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers. The image for the picture and icon fields can be different or the same.
+This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers. The script will update each item that is returned in the query with the images set
+in the iconSysId and pictureSysId variables. A business use for this script would be the need to update the picture and icon fields of all Apple related catalog items with an new Apple logo image.
 
 ## Getting Started
 

--- a/Fix scripts/Bulk Update Catalog Item Images/readme.md
+++ b/Fix scripts/Bulk Update Catalog Item Images/readme.md
@@ -4,19 +4,19 @@ Updates the image(s) associated with catalog items or record producers
 
 ## Description
 
-This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers.
+This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers. The image for the picture and icon fields can be different or the same.
 
 ## Getting Started
 
 ### Dependencies
 
 * Must be in the Global scope.
-* The image being used must already exist in the db_image table.
+* The image(s) being used must already exist in the db_image table.
 
 ### Execution
 
 1. Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
-2. Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
+2. Copy the sys_id(s) from the image that you will using from the sys_attachments table. You can use the same image for both fields or different images, it's up to you. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
 3. Update the script variables as follows:
     * **table**: the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
     * **iconSysId**: the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)

--- a/Fix scripts/Bulk Update Catalog Item Images/readme.md
+++ b/Fix scripts/Bulk Update Catalog Item Images/readme.md
@@ -1,0 +1,36 @@
+# Bulk Catalog Item Image Change
+
+Updates the image(s) associated with catalog items or record producers
+
+## Description
+
+This script can perform bulk updates of the picture and/or icon fields used in catalog items and record producers.
+
+## Getting Started
+
+### Dependencies
+
+* Must be in the Global scope.
+* The image being used must already exist in the db_image table.
+
+### Execution
+
+1. Copy the script from bulk-update-cat-item-images.js to either a fix script or background script in your ServiceNow instance.
+2. Copy the sys_id(s) from the image that you will using from the sys_attachments table. If you have added this image using the db_image table, you can filter the sys_attachments table name column to ZZ_YYdb_image to make it easier to find.
+3. Update the script variables as follows:
+    * **table**: the table you want to change the icons for the catalog item(s) - commonly sc_cat_item or sc_cat_item_producer
+    * **iconSysId**: the sys_id of the image to be used for the icon (NOTE - you can comment this line out if you don't want to update the icon)
+    * **pictureSysId**: the sys_id of the image to be used for the picture (NOTE - you can comment this line out if you don't want to update the picture)
+    * **query**: the encoded query you will use to identify the items to be updated
+4. Run the script and the picture and/or icon fields will be updated
+
+## Authors
+
+Brad Warman
+
+https://www.servicenow.com/community/user/viewprofilepage/user-id/80167
+
+## Version History
+
+* 0.1
+    * Initial Release


### PR DESCRIPTION
Update to #956. Bulk catalog item image update script. This script allows for the bulk update of catalog item pictures and icons via a fix or background script.