### PR TITLE
Use case of addOption() and removeOption() in onChange client script for priority field

### DIFF
--- a/Client Scripts/Use case of addOption and removeOption for priority/readme.md
+++ b/Client Scripts/Use case of addOption and removeOption for priority/readme.md
@@ -1,0 +1,3 @@
+# onChange client script for table 'change_request' where field is 'priority'
+if priority is critical, impact can be high and medium i.e, low will be removed from choice list using removeOption()
+and for other priority ,impact can be high, medium and low i.e, low option will be added, using addOption()

--- a/Client Scripts/Use case of addOption and removeOption for priority/script.js
+++ b/Client Scripts/Use case of addOption and removeOption for priority/script.js
@@ -1,0 +1,10 @@
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+   if (isLoading || newValue === '') {
+	return;
+   }
+   if(newValue == 1) {
+	g_form.removeOption('impact',3); // 3 is the value for impact 'low'
+   } else {
+	g_form.addOption('impact', '3 - Low');
+   }
+}


### PR DESCRIPTION
if priority is critical, impact can be high and medium i.e, low will be removed from choice list using removeOption()
and for other priority , impact can be high, medium and low i.e, low option will be added, using addOption()