### PR TITLE
Pull mrvs value

### DIFF
--- a/Catalog Client Script/Fetch MRVS variable from Parent/get_set_mrvs_variable_value.js
+++ b/Catalog Client Script/Fetch MRVS variable from Parent/get_set_mrvs_variable_value.js
@@ -1,0 +1,11 @@
+/*
+The g_service_catalog API enables you to access data in a multi-row variable set (MRVS) when a model is open.
+This API is available in all environments, such as, Service Portal, Now Platform, Workspace, and Now® Mobile.
+*/
+
+function onLoad() {
+  if (g_service_catalog.parent.getValue("address_type") == "ipv4") {
+    g_form.setValue("ipv4_address", "XX.XX.XX.XX");
+    g_form.setVisible("ipv6_address", "false");
+  }
+}

--- a/Catalog Client Script/Fetch MRVS variable from Parent/readme.md
+++ b/Catalog Client Script/Fetch MRVS variable from Parent/readme.md
@@ -1,0 +1,14 @@
+# How to fetch MRVS value using g_service_catalog
+
+Use this onLoad catalog client script to fetch the MRVS variable value and hide the variable.  In this example, a catalog item for blocking multiple IP addresses on a firewall has a variable **address_type** with two choices - IPV4 and IPV6. The MRVS has two variables (ipv4_address and ipv6_address) for the respective address types. If the Address type field on the parent form is set to IPV4, the field IPV6 address is hidden on the MRVS.
+
+It returns the value of the specified field on the catalog item form when used in a client script on multi-row variable sets (MRVS).
+
+**Note: This method can only be called from the parent object, such as g_service_catalog.parent.getValue().**
+
+## Use case
+
+Use this method when an MRVS modal is open for editing or creating and you want to modify data within the MRVS based on the value of a field on the parent catalog item form. 
+**For example:** when you need to modify the contents of the cells within an MRVS based on a check box on the parent form. You can also use this method to access the data of other MRVS elements within the same parent form.
+
+* [Click here for Get & Set MRVS Variable Value script](get_set_mrvs_variable_value.js)


### PR DESCRIPTION
How to fetch & set MRVS value using g_service_catalog

Use this onLoad catalog client script to fetch the MRVS variable value and hide the variable.  In this example, a catalog item for blocking multiple IP addresses on a firewall has a variable **address_type** with two choices - IPV4 and IPV6. The MRVS has two variables (ipv4_address and ipv6_address) for the respective address types. If the Address type field on the parent form is set to IPV4, the field IPV6 address is hidden on the MRVS.