### PR TITLE
Get mrvs value

### DIFF
--- a/Catalog Client Script/Get Display Value of MRVS/mrvs.js
+++ b/Catalog Client Script/Get Display Value of MRVS/mrvs.js
@@ -1,0 +1,8 @@
+
+var script = new global.VariableUtil();
+var gr = new GlideRecord("sc_req_item");
+gr.addEncodedQuery("sys_id=<Copy & Paste RITM Sys ID>");
+gr.query();
+if (gr.next()) {
+    gs.info(script.getDisplayValue('<MRVS Variableset SYSID>', gr.variables.MRVSName)); //MRVS Display Value
+}

--- a/Catalog Client Script/Get Display Value of MRVS/readme.md
+++ b/Catalog Client Script/Get Display Value of MRVS/readme.md
@@ -1,0 +1,7 @@
+## Get Display Value of MultiRow Variableset (MRVS)
+
+While there are different ways to do this, the easiest of them is to leverage an out of box script named **'VariableUtil'**. 
+
+The script is present in the global scope and contains an function named getDisplayValue aptly. This function seems to work on both the normal variable as well as multirow variableset. You just need to pass the sysid of the variable or the multirow variableset and its corresponding value.
+
+**new VariableUtil().getDisplayValue('sys_id of variable or MRVS','value of variable/MRVS');**


### PR DESCRIPTION
## Get Display Value of MultiRow Variableset (MRVS)

While there are different ways to do this, the easiest of them is to leverage an out of box script named **'VariableUtil'**. 

The script is present in the global scope and contains an function named getDisplayValue aptly. This function seems to work on both the normal variable as well as multirow variableset. You just need to pass the sysid of the variable or the multirow variableset and its corresponding value.

