### PR TITLE
Users without manager

### DIFF
--- a/Background Scripts/Get all users where manager is empty/readme.md
+++ b/Background Scripts/Get all users where manager is empty/readme.md
@@ -1,0 +1,10 @@
+# Get all users without manager
+
+Use the script in script.js file to get the list of all users in sys_user table who do not have an manager.
+This GlideRecord script can be used in multiple places. For example in background scripts.
+
+### Did some optimization in the code
+1. Used different variable name instead of gr to reference a GlideRecord object.
+2. Used addActiveQuery() method to filter out just the active records.
+3. Used getDisplayValue() method to push string values in the array instead of using dot notation.
+4. Used self executing function to wrap the code in a function for reducing variable scoping issues.

--- a/Background Scripts/Get all users where manager is empty/script.js
+++ b/Background Scripts/Get all users where manager is empty/script.js
@@ -1,0 +1,12 @@
+(function () {
+    var users = [];
+    var userGr = new GlideRecord('sys_user'); // used different variable name instead of gr.
+    userGr.addActiveQuery(); // used to filter more on the records fetched.
+    userGr.addNullQuery('manager');
+    userGr.query();
+    while (userGr.next()) {
+        users.push(userGr.getDisplayValue()); // used getDisplayValue() method to get the name as a string instead of using gr.name
+    }
+    gs.info("Users without manager are : " + users);
+
+})(); // Used a self executing function to wrap the code with a function for reducing variable scoping issues


### PR DESCRIPTION
# Get all users without manager

Use the script in script.js file to get the list of all users in sys_user table who do not have an manager.
This GlideRecord script can be used in multiple places. For example in background scripts.
