### PR TITLE
Business rule: Major incident is true them create problem

### DIFF
--- a/Business Rules/AutoCreation of Problem from Incident/readme.md
+++ b/Business Rules/AutoCreation of Problem from Incident/readme.md
@@ -1,0 +1,7 @@
+This is After- Business rule Created on Incident Table.
+In which I have enabled Both insert and Update check Box to true.
+Intially, we will create a field called major Incident(true/false field).
+If the user checks that and updates an Incident record Immediately a Problem record will be generated with the current values of the Incident
+A pop up message will be displayed as well.
+If we want we can even put the condition's that only an incident manager can enable this checkBox
+Without Installing the Major Incident Managment plugin, we can use this. But this will provide limted features for free.

--- a/Business Rules/AutoCreation of Problem from Incident/whenMajorIncidentIsTrueCreateProblem.js
+++ b/Business Rules/AutoCreation of Problem from Incident/whenMajorIncidentIsTrueCreateProblem.js
@@ -1,0 +1,16 @@
+//This is a After-Busiens Rule with insert and update(checked) created on Incident Table
+//condition as Major Incident is True
+(function executeRule(current, previous /*null when async*/ ) {
+
+    
+    var gr = new GlideRecord('problem');
+    gr.initialize();
+    gr.first_reported_by_task = current.getUniqueValue();
+    gr.business_service = current.business_service.getValue();
+    gr.short_description = current.short_description;
+    gr.description = current.description;
+	gr.urgency = current.urgency;
+	gr.impact= current.impact;
+    gr.insert();
+	gs.addInfoMessage('problem number'+gr.number.getDisplayValue());
+})(current, previous);


### PR DESCRIPTION
This is After- Business rule Created on the Incident Table. In which I have enabled Both the insert and Update check Box to true. Initially, we will create a field called major Incident(true/false field) and condition is major incident is true. If the user checks that and updates an Incident record Immediately a Problem record will be generated with the current values of the Incident A pop-up message will be displayed as well. If we want we can even put the condition that only an incident manager can enable this checkBox Without Installing the Major Incident Management plugin, we can use this. But this will provide limited features for free.