### PR TITLE
Business rule: Without Attached Incident Emergency Change cannot be closed

### DIFF
--- a/Business Rules/Emergency Change Cannot be closed without AttachedIncident/Review to Close Without Incident.js
+++ b/Business Rules/Emergency Change Cannot be closed without AttachedIncident/Review to Close Without Incident.js
@@ -1,0 +1,16 @@
+//before business rule is used and update only checked
+//conditions were type is emergency AND State changes to closed
+// if these conditions met and there is no attached incidents to this emergency change request then, we don't let the user to close the Change request
+
+(function executeRule(current, previous /*null when async*/ ) {
+
+    var inc = new GlideAggregate('incident');//we glide the incident table to get the value of current change request having any incidents or not
+    inc.addQuery("rfc", current.getUniqueValue()); //instead of sys_id we used getUniqueValue
+    inc.query();
+	//if any incident found then its fine and we can move it to close state
+  ..if No incident found then we will abort the action and send's a pop-up message to the user
+    if (!inc.hasNext()){
+        gs.addErrorMessage('Emergency change cannot be moved from review to close without an attached incident in Incidents Fixed by change');
+        current.setAbortAction(true);
+    }
+})(current, previous);

--- a/Business Rules/Emergency Change Cannot be closed without AttachedIncident/readme.md
+++ b/Business Rules/Emergency Change Cannot be closed without AttachedIncident/readme.md
@@ -1,0 +1,6 @@
+1. This is a Before-Busines rule created on Change Request Table
+2. I used GlideAggregate API.
+3. only update is checked
+4. conditions were Type is Emergency AND State changes to Close.
+5. For emergency change Request, if there are no attached incident's to it then we don't let the user to move the state to close.
+6. We use glideAggregate to glide Incident table and if we find any incident's user can move the state to close, But if there is no records then user action will be aborted.


### PR DESCRIPTION
1. This is a Before-Busines rule created on the Change Request Table
2. I used GlideAggregate API.
3. only update is checked
4. conditions were Type is Emergency AND State changes to Close.
5. For emergency change Requests, if there are no attached incidents to it then we don't let the user to move the state to close.
6. We use glideAggregate to glide the Incident table and if we find any incident's user can move the state to close, But if there is no records then the user action will be aborted.