### PR TITLE
Set incident as critical priority

### DIFF
--- a/UI Actions/Set Incident Priority Critical/readme.md
+++ b/UI Actions/Set Incident Priority Critical/readme.md
@@ -1,0 +1,19 @@
+Set Incident Priority Critical
+
+This UI Action sets current incident record as priority as Critical.
+
+When clicked
+Below Conformation message will be displayed to the user as below
+"Are you sure you want to set priority as Critical?"
+
+If user selects cancel nothing will happen.
+
+If user selects confirm then
+a) It sets the Priority of the current Record as 1-Critical by setting Urgency and Impact as 1-High.
+b) It also sets 'assigned_to' field as 'logedin user'.
+c) It also upends the description as "Priority is set to Critical by 'logedin User'".
+
+** Please note that it changes field values only on the form that is client side. 
+Unless you submit or update the record, field values will not be updated in the database table records.
+
+You can use this as reference to set other field values as well.

--- a/UI Actions/Set Incident Priority Critical/script.js
+++ b/UI Actions/Set Incident Priority Critical/script.js
@@ -1,0 +1,9 @@
+// Call this function from OnClick field of UI Action form
+function ClientSideScript() {
+    var answer = confirm("Are you sure you want to set priority as Critical?");
+    if (answer == true) {
+        g_form.setValue('assigned_to', g_user.userID);
+        g_form.setValue('impact', 1);
+        g_form.setValue('urgency', 1);
+        g_form.setValue('description', g_form.getValue('description') + "\nPriority is set to Critical by " + g_user.getFullName());
+    }


### PR DESCRIPTION
This UI Action sets current incident record as Critical priority.

When clicked
Conformation message will be displayed to the user as below
Are you sure you want to set priority as Critical?

If user selects cancel nothing will happen 

If user selects confirm then
a) It sets the Priority of the current Record as 1-Critical by setting Urgency and Impact as 1-High.
b) It also sets 'assigned_to' field as 'logedin user'.
c) It also upends the description as "Priority is set to Critical by 'logedin User'".

Please note that it changes field values only on the form that is client side. 
Unless you submit or update the record field values will not be updated in the database table records.

You can use this as reference to set other field values as well
