### PR TITLE
Usage of getLink() and chooseWindow() methods are added

### DIFF
--- a/GlideRecord/Choose Window for better performance/README.md
+++ b/GlideRecord/Choose Window for better performance/README.md
@@ -1,0 +1,3 @@
+chooseWindow method is used to paginate the records while using Glide Record on any table.
+This method allows you to paginate through records, fetching only a window (subset) of records, which can be useful for performance when dealing with large datasets. 
+summary : Paginate large result sets by selecting a window of records.

--- a/GlideRecord/Choose Window for better performance/script.js
+++ b/GlideRecord/Choose Window for better performance/script.js
@@ -1,0 +1,6 @@
+var gr = new GlideRecord('incident');
+gr.chooseWindow(0, 10); // Fetch the first 10 records
+gr.query();
+while (gr.next()) {
+  gs.info(gr.number);
+}

--- a/GlideRecord/Get link for the Record/README.md
+++ b/GlideRecord/Get link for the Record/README.md
@@ -1,0 +1,2 @@
+getLink() generates a direct URL to the record, useful for embedding links to records in notifications or logging them.
+Summary: Generate a URL link to the record.

--- a/GlideRecord/Get link for the Record/script.js
+++ b/GlideRecord/Get link for the Record/script.js
@@ -1,0 +1,4 @@
+var gr = new GlideRecord('incident');
+if (gr.get('sys_id_of_record')) {
+  gs.info('Incident link: ' + gr.getLink());
+}


### PR DESCRIPTION
feat: Add usage examples for getLink() and chooseWindow() methods in GlideRecord

- Implemented getLink() method to generate a URL for the GlideRecord, which can be used in notifications or logs for direct access to records.
- Added chooseWindow() method to demonstrate how to paginate query results by selecting a window of records, improving performance when handling large datasets.
- Updated documentation with examples for both methods to showcase practical use cases.

This commit enhances the ability to generate record URLs and optimize querying large datasets.