### PR TITLE
Create ConvertAttachmentToBase64.js

### DIFF
--- a/Background Scripts/Convert Attachment To Base 64/ConvertAttachmentToBase64.js
+++ b/Background Scripts/Convert Attachment To Base 64/ConvertAttachmentToBase64.js
@@ -1,0 +1,16 @@
+/* attGr is a GlideRecord from sys_attachment table */
+
+function attachmentToBase64(attGr) {
+
+    /* constructor of GlideSysAttachment class */
+    var gst = new GlideSysAttachment();
+
+    /* fetching the attachment content in bytes */
+    var bytes = gst.getBytes(attGr);
+
+    /* encoding the bytes in base64 format */
+    var base64Content = GlideStringUtil.base64Encode(bytes);
+
+    return base64Content;
+
+}


### PR DESCRIPTION
A code snippet to convert a ServiceNow attachment to base64 encoded string