### PR TITLE
Utility: Validate the email address in the catalog whenever user is going to add another email

### DIFF
--- a/Catalog Client Script/MRVS Email Validation with Mutation Observer/EmailValidationOnCatalogUI.js
+++ b/Catalog Client Script/MRVS Email Validation with Mutation Observer/EmailValidationOnCatalogUI.js
@@ -1,0 +1,65 @@
+/**
+ * This is a client script that validates the email address in the MRVS field.
+ * It uses MutationObserver to observe the changes in the MRVS field.
+ * UseCase: Validate the email address in the catalog whenever user is going to add another email, 
+ * and show an error message if a duplicate email address is found. 
+ */
+function onLoad() {
+    var document = document || top.document;
+
+    var duplicateErrorMessageStatus = false; //adding this as corner case as observer will be called multiple times
+
+    setTimeout(function () {
+        var tbody = document.querySelector("#user_details > div > tbody");
+
+        if (tbody) {
+            var observer = new MutationObserver(function (m, o) {
+
+                var users = g_form.getValue('user_details');
+
+                var hasDuplicateEmails = validateUserDetails();
+
+                if (!users || hasDuplicateEmails) {
+                    if (hasDuplicateEmails && !duplicateErrorMessageStatus) {
+                        g_form.addErrorMessage('Duplicate email address found');
+                        duplicateErrorMessageStatus = true;
+                    }
+                    //disable the submit button
+                } else {
+                    duplicateErrorMessageStatus = false;
+                    g_form.clearMessages();
+                    //enable the submit button
+                }
+
+            });
+            observer.observe(tbody, {
+                attributes: true,
+                childList: true,
+                subtree: true
+            });
+        }
+    }, 3000);
+
+}
+
+// MRVS contains the user details in the form of JSON
+function validateUserDetails() {
+    var userDetailsMRVS = g_form.getValue('user_details');
+    if (userDetailsMRVS) {
+        var multiRowData = JSON.parse(userDetailsMRVS);
+        var emailSet = new Set();
+
+        for (var i = 0; i < multiRowData.length; i++) {
+            var row = multiRowData[i];
+
+            var email = row.email.trim().toLowerCase();
+
+            if (emailSet.has(email)) {
+
+                return true;
+            }
+            emailSet.add(email);
+        }
+    }
+    return false;
+}

--- a/Catalog Client Script/MRVS Email Validation with Mutation Observer/readme.md
+++ b/Catalog Client Script/MRVS Email Validation with Mutation Observer/readme.md
@@ -1,0 +1,22 @@
+# Email Validation on Catalog UI
+
+This file contains a client script that validates email addresses in the MRVS (Multi-Row Variable Set) field using a MutationObserver. The script ensures that duplicate email addresses are not allowed in the catalog.
+
+## File Structure
+
+- `/code-snippets/Catalog Client Script/MRVS Email Validation with Mutation Observer/EmailValidationOnCatalogUI.js`
+
+## Description
+
+The script observes changes in the MRVS field and validates the email addresses whenever a user attempts to add another email. If a duplicate email address is found, an error message is displayed, and the submit button is disabled.
+
+## Usage
+
+1. **onLoad Function**: This function initializes the MutationObserver to watch for changes in the MRVS field.
+2. **validateUserDetails Function**: This function checks for duplicate email addresses in the MRVS field.
+
+## How It Works
+
+1. The `onLoad` function sets up a MutationObserver on the MRVS field.
+2. When changes are detected, the `validateUserDetails` function is called to check for duplicate email addresses.
+3. If duplicates are found, an error message is displayed, and the submit button is disabled.


### PR DESCRIPTION
This is a client script that validates the email address in the MRVS field. It uses MutationObserver to observe the changes in the MRVS field.

UseCase: Validate the email address in the catalog whenever user is going to add another email, and show an error message if a duplicate email address is found.