### PR TITLE
 Fix script to regenerate the draft document if the dynamic field values used in the template have changed

### DIFF
--- a/Fix scripts/Employee document management/read.md
+++ b/Fix scripts/Employee document management/read.md
@@ -1,2 +1,4 @@
-**Use case:** The document was generated with the dynamic fields selected in the document template. But if the field values changes after document generation then these changes will not be reflected in the generated document.<br />
-**Solution:** Leverage EDM utils provided OOB and call these utilities to regenerate the documents. After this script runs, a new record will be created in draft_document table. The previous version of the document in draft_document will be set to inactive
+# Regenerate the draft document created for e-signature (or) regenerate the draft document if the field values changed after the draft document had created <br />
+
+***Use case:*** The document was generated with the dynamic fields selected in the document template. But if the field values changes after document generation then these changes will not be reflected in the generated document.<br /><br />
+***Solution:*** Leverage EDM utils provided OOB and call these utilities to regenerate the documents. After this script runs, a new record will be created in draft_document table. The previous version of the document in draft_document will be set to inactive

--- a/Fix scripts/Employee document management/read.md
+++ b/Fix scripts/Employee document management/read.md
@@ -1,0 +1,2 @@
+**Use case:** The document was generated with the dynamic fields selected in the document template. But if the field values changes after document generation then these changes will not be reflected in the generated document.<br />
+**Solution:** Leverage EDM utils provided OOB and call these utilities to regenerate the documents. After this script runs, a new record will be created in draft_document table. The previous version of the document in draft_document will be set to inactive

--- a/Fix scripts/Employee document management/regenerate_document.js
+++ b/Fix scripts/Employee document management/regenerate_document.js
@@ -1,0 +1,16 @@
+var gr = new GlideRecord('VALID_TABLE_NAME');
+gr.addEncodedQuery('PASS_VALID_QUERY_To_TARGET_RECORDS_WHICH_HAVE_DOCUMENTS_THAT_NEEDS_TO_BE_REGENERATED');
+gr.query();
+while (gr.next()) {
+
+    if (new hr_PdfUtils().isValidPdfTemplateForPreFill(gr.pdf_template.sys_id)) { //Check if it is a pre-filled type of document or editable pdf document
+        var pdfDraftSysId = new hr_PdfUtils().prefillPdfTemplate(gr.pdf_template.sys_id, false, gr.sys_id, gr.sys_class_name, gr.sys_id);
+        if (gs.nil(pdfDraftSysId))
+            gs.info('Error occurred while generating pdf for ' + gr.sys_id);
+    } else {
+        new GeneralHRForm().inactivateRelatedDrafts(gr.sys_class_name, gr.sys_id);
+        var caseAjax = new hr_CaseAjax();
+        var document = caseAjax.documentBody(gr.sys_class_name, gr.sys_id, gr.sys_class_name, gr.sys_id, 'true');
+        caseAjax.setDocumentBody(document.body, gr.sys_class_name, gr.sys_id, gr.sys_class_name, gr.sys_id);
+    }
+}


### PR DESCRIPTION
Leverage HR Document utils provided OOB and call these utilities to regenerate the documents. After this script runs, a new record will be created in draft_document table. The previous version of the document in draft_document will be set to inactive