### PR TITLE
Dynamically update reference qualifier

### DIFF
--- a/Catalog Client Script/Dynamically Update Reference Qualifier/Catalog Item onLoad.js
+++ b/Catalog Client Script/Dynamically Update Reference Qualifier/Catalog Item onLoad.js
@@ -1,0 +1,18 @@
+function onLoad() {
+	var filterString = 'sys_class_name=cmdb_ci_ip_router^ORsys_class_name=cmdb_ci_ip_switch^ORsys_class_name=cmdb_ci_vpn' //Reference qualifier for this Catalog Item
+	//alternate method for Service Portal only
+	// if (window == null){ //Service Portal method
+	// 	var setfilter = g_list.get('v_configuration_item');
+	// 	setfilter.setQuery(filterString);
+	// } else { //native UI method
+		var ga = new GlideAjax('refQualUtils'); //Client callable Script Include Name
+		ga.addParam('sysparm_name', 'setSysProp'); //Function in Script Include
+		ga.addParam('sysparm_sys_prop_name', 'sr.ref_qual.ci'); //System Property Name used in Reference qualifier 
+		ga.addParam('sysparm_sys_prop_value', filterString);
+		ga.getXML(getResponse);
+			
+		function getResponse(response) { //to avoid Service Portal 'There is a JavaScript error in your browser console'
+			var answer = response.responseXML.documentElement.getAttribute("answer"); 
+		}
+	//}
+}

--- a/Catalog Client Script/Dynamically Update Reference Qualifier/Script Include.js
+++ b/Catalog Client Script/Dynamically Update Reference Qualifier/Script Include.js
@@ -1,0 +1,13 @@
+var refQualUtils = Class.create();
+refQualUtils.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+   
+   	setSysProp: function(){
+		var propertyName = this.getParameter('sysparm_sys_prop_name');
+		var propertyValue =  this.getParameter('sysparm_sys_prop_value');
+		var property = gs.getProperty(propertyName);
+		gs.setProperty(propertyName, propertyValue);
+		return;
+	},
+		
+    type: 'refQualUtils'
+});

--- a/Catalog Client Script/Dynamically Update Reference Qualifier/Variable Set onLoad.js
+++ b/Catalog Client Script/Dynamically Update Reference Qualifier/Variable Set onLoad.js
@@ -1,0 +1,18 @@
+function onLoad() {
+	var filterString = 'sys_class_name=cmdb_ci_ip_router^ORsys_class_name=cmdb_ci_ip_switch' //Reference qualifier that was replaced
+	//alternate method for Service Portal only
+	// if (window == null){ //Service Portal method
+	// 	var setfilter = g_list.get('v_configuration_item');
+	// 	setfilter.setQuery(filterString);
+	// } else { //native UI method
+		var ga = new GlideAjax('refQualUtils'); //Client callable Script Include Name
+		ga.addParam('sysparm_name', 'setSysProp'); //Function in Script Include
+		ga.addParam('sysparm_sys_prop_name', 'sr.ref_qual.ci'); //System Property Name used in Reference qualifier 
+		ga.addParam('sysparm_sys_prop_value', filterString);
+		ga.getXML(getResponse);
+			
+		function getResponse(response) { //to avoid Service Portal 'There is a JavaScript error in your browser console'
+			var answer = response.responseXML.documentElement.getAttribute("answer"); 
+		}
+	//}
+}

--- a/Catalog Client Script/Dynamically Update Reference Qualifier/readme.md
+++ b/Catalog Client Script/Dynamically Update Reference Qualifier/readme.md
@@ -1,23 +1,23 @@
-When we have a reference variable that is used in a (single row) variable set, sometimes we want to update the Reference qualifier only for specific Catalog Item(s)
+When we have a reference variable that is used in a (single row) variable set, sometimes we want to update the Reference qualifier only for specific Catalog Item(s).
 
-In this simplified example, I have a Configuration item (v_configuration_item) reference variable (cmdb_ci table) in a single row variable set that has been included in a number of Catalog Items.  The simple Reference qualifier for this variable is:
+In this example, I have a Configuration item (named v_configuration_item) reference variable (cmdb_ci table) in a single row variable set that has been included in a number of Catalog Items.  The simple Reference qualifier for this variable is:
 sys_class_name=cmdb_ci_ip_router^ORsys_class_name=cmdb_ci_ip_switch
 
 Let's say for one particular Catalog Item, I also want to include the class of VPN (cmdb_ci_vpn).
 
-To do this without having to create another variable with the new qualifier and hiding the variable set variable, there are some preparation steps which include those which ensure that the other Catalog Items using the variable set are not disrupted:
+To do this without having to create another variable with the new qualifier and hiding the variable set variable, there are some preparation steps, including those which ensure that the other Catalog Items using the variable set are not disrupted:
 
-1) Change the advanced reference qualifier on the variable to: javascript: gs.getProperty("sr.ref_qual.ci");
+1) Change the advanced reference qualifier on the variable to: **javascript: gs.getProperty("sr.ref_qual.ci");**
 using a System Property Name of your choice
 
 2) Create a System Property with the same Name used in the Reference qualifier, leaving the Value empty.
 
-3) Use the included 'Variable Set onLoad' Catalog Client Script that applies to the Variable set with...
+3) Add the included 'Variable Set onLoad' Catalog Client Script that applies to the Variable set with...
 
 4) The included Client Callable Script Include to update the System Property Value to the Reference Qualifier that was replaced.  This Script Include uses parameters for the System Property Name and Value, so it can be re-used in every instance of this solution.
 
 Now that the other Catalog Items using the variable set are still working as they were, all you need to do to update the Reference qualifier on certain Catalog Item(s) is:
 
-5) Use the included 'Catalog Item onLoad' Catalog Client Script that applies to the Catalog Item.
+5) Add the included 'Catalog Item onLoad' Catalog Client Script that applies to the Catalog Item.
 
 This solution works in both the Native UI and Service Portal. The Catalog Client scripts contain an alternate Service Portal only approach in the commented if block that can be used in conjunction with the native UI approach in the else block. This alternate Service Portal solution was developed in collaboration with Chris Perry.

--- a/Catalog Client Script/Dynamically Update Reference Qualifier/readme.md
+++ b/Catalog Client Script/Dynamically Update Reference Qualifier/readme.md
@@ -1,0 +1,23 @@
+When we have a reference variable that is used in a (single row) variable set, sometimes we want to update the Reference qualifier only for specific Catalog Item(s)
+
+In this simplified example, I have a Configuration item (v_configuration_item) reference variable (cmdb_ci table) in a single row variable set that has been included in a number of Catalog Items.  The simple Reference qualifier for this variable is:
+sys_class_name=cmdb_ci_ip_router^ORsys_class_name=cmdb_ci_ip_switch
+
+Let's say for one particular Catalog Item, I also want to include the class of VPN (cmdb_ci_vpn).
+
+To do this without having to create another variable with the new qualifier and hiding the variable set variable, there are some preparation steps which include those which ensure that the other Catalog Items using the variable set are not disrupted:
+
+1) Change the advanced reference qualifier on the variable to: javascript: gs.getProperty("sr.ref_qual.ci");
+using a System Property Name of your choice
+
+2) Create a System Property with the same Name used in the Reference qualifier, leaving the Value empty.
+
+3) Use the included 'Variable Set onLoad' Catalog Client Script that applies to the Variable set with...
+
+4) The included Client Callable Script Include to update the System Property Value to the Reference Qualifier that was replaced.  This Script Include uses parameters for the System Property Name and Value, so it can be re-used in every instance of this solution.
+
+Now that the other Catalog Items using the variable set are still working as they were, all you need to do to update the Reference qualifier on certain Catalog Item(s) is:
+
+5) Use the included 'Catalog Item onLoad' Catalog Client Script that applies to the Catalog Item.
+
+This solution works in both the Native UI and Service Portal. The Catalog Client scripts contain an alternate Service Portal only approach in the commented if block that can be used in conjunction with the native UI approach in the else block. This alternate Service Portal solution was developed in collaboration with Chris Perry.


### PR DESCRIPTION
When we have a reference variable that is used in a (single row) variable set, sometimes we want to update the Reference qualifier only for specific Catalog Item(s).  This solution replaces the common workaround of creating a Catalog Item variable with the new qualifier and hiding the variable set variable.

Now we can dynamically change a reference qualifier!!!

