### PR TITLE
Comments without dateTime

### DIFF
--- a/Background Scripts/findTableSize.js
+++ b/Background Scripts/findTableSize.js
@@ -1,0 +1,11 @@
+var table_name = 'sys_attachment_doc'; //The file data of attachment is stored in this Table in ServiceNow
+
+var tabSizeinGB = new GlideRecord('sys_physical_table_stats');
+tabSizeinGB.addQuery('table_name', table_name); //Querying with the 'sys_attachment_doc' table to get the size of it
+tabSizeinGB.setLimit(1); //This will limit to one record query
+tabSizeinGB.query();
+if (tabSizeinGB.next()) {
+    gs.info('[' + tabSizeinGB.getValue('table_name') +']' + ' table Size is: ' + tabSizeinGB.getValue('table_size_in_gb') + ' GB');
+} else {
+    gs.info('Table not found!');
+}

--- a/Mail Scripts/Comments without Date Time/commentsWithoutDateTime.js
+++ b/Mail Scripts/Comments without Date Time/commentsWithoutDateTime.js
@@ -1,0 +1,5 @@
+(function runMailScript(current, template, email, email_action, event) {
+
+    current.comments.getJournalEntry(1).match(/\n.*/gm).join('').replace(/^\s*\n/gm, ""); //getting the comments without the username,date/time
+
+})(current, template, email, email_action, event);

--- a/Mail Scripts/Comments without Date Time/readme.md
+++ b/Mail Scripts/Comments without Date Time/readme.md
@@ -1,0 +1,14 @@
+Retrieves the most recent comment (journal entry) from the comments field of the current record.
+current.comments.getJournalEntry(1)
+
+
+Extracting the Comment's Content (Removing Username/Date/Time):
+.match(/\n.*/gm):
+Matches all text after the first newline (\n). In ServiceNow, journal entries typically start with a username, date, and time stamp followed by the comment text. This regex targets everything after the first line, effectively bypassing the username and timestamp.
+.join(''):
+Joins the matched lines back into a single string. The empty string ('') is used to remove any newlines in the matched parts.
+.replace(/^\s*\n/gm, ""):
+This removes any leading empty lines (^\s*\n) or unnecessary whitespace that may remain after removing the username/timestamp, ensuring the comment starts cleanly with actual content.
+
+
+Result: The final output is the content of the most recent comment without the username, date, or time. This is useful for including clean, user-entered content in an email notification, without system-generated metadata like when the comment was added or who added it.


### PR DESCRIPTION
This email script is designed to extract and format the most recent comments from the current record in ServiceNow, while removing the username and timestamp typically associated with journal entries. It uses JavaScript methods to manipulate the string content of the most recent journal entry before including it in an email notification.