### PR TITLE
Background Script to check which flow runs on any given specific table

### DIFF
--- a/Background Scripts/Get names of flows runs on specific table
+++ b/Background Scripts/Get names of flows runs on specific table
@@ -1,0 +1,16 @@
+var grActionInstance = new GlideAggregate('sys_hub_action_instance');
+var strTableName = 'change_request';  //replace with your table name
+
+grActionInstance.addJoinQuery('sys_variable_value', 'sys_id', 'document_key').addCondition('value', strTableName);
+grActionInstance.addAggregate('GROUP_CONCAT_DISTINCT', 'flow'); 
+grActionInstance.groupBy('flow');
+grActionInstance.addQuery('flow.sys_class_name', 'sys_hub_flow')
+grActionInstance.query();
+
+while(grActionInstance.next()) {
+    gs.info(
+        '[{0}]\t{1}', 
+        grActionInstance.flow.active ? 'active' : 'inactive', 
+        grActionInstance.flow.name
+    );
+}

--- a/README.md.txt
+++ b/README.md.txt
@@ -1,0 +1,5 @@
+This Background script checks  which flow running on any given specific table.
+
+You need to put table name on below line from code on which you want to see the all the running flows. 
+
+var strTableName = 'change_request'; //replace with your table name


### PR DESCRIPTION
This background script will return all the flows runs on specific table. Input required to mention table name on which flows to check.