### PR TITLE
Calculate age of incident

### DIFF
--- a/Background Scripts/Find Age of Incidents/ageOfIncidents.js
+++ b/Background Scripts/Find Age of Incidents/ageOfIncidents.js
@@ -1,0 +1,9 @@
+var grIncidentAge = new GlideRecord('incident');
+grIncidentAge.query();
+while (grIncidentAge.next()) {
+    var incCreated = new GlideDateTime(grIncidentAge.sys_created_on);
+    var nowDT = new GlideDateTime();
+    var ageInMilliseconds = nowDT.getNumericValue() - incCreated.getNumericValue(); //The numeric values of the current and created dates are obtained, and the difference is calculated to find the age of the incident in milliseconds.
+    var ageInDays = Math.floor(ageInMilliseconds / (1000 * 60 * 60 * 24)); //The age in milliseconds is converted to days by dividing by the number of milliseconds in a day (1,000 milliseconds/second * 60 seconds/minute * 60 minutes/hour * 24 hours/day). The result is rounded down using Math.floor().
+    gs.info('Incident ' + grIncidentAge.number + ' is ' + ageInDays + ' days old.');
+}

--- a/Background Scripts/Find Age of Incidents/readme.md
+++ b/Background Scripts/Find Age of Incidents/readme.md
@@ -1,0 +1,27 @@
+This script is designed to calculate the age of incidents in the ServiceNow platform by comparing the creation date of each incident with the current date. 
+It retrieves all the records from the `incident` table and iterates through them. For each incident, it calculates the time difference between its creation date (`sys_created_on`) 
+and the current date in milliseconds, then converts that value into days. Finally, it logs the age of each incident in the system logs, along with its incident number. 
+This approach is useful for monitoring how long incidents have been open, helping teams prioritize older issues and ensuring timely resolution. Whether you're tracking overall service 
+performance or looking for bottlenecks in your incident management processes, this script can provide valuable insights into the duration of open incidents, aiding in improving service delivery.
+
+
+var grIncidentAge = new GlideRecord('incident');
+//This line creates a new GlideRecord object for the incident table, allowing the script to query and manipulate incident records.
+
+grIncidentAge.query();
+//This line executes a query to retrieve all records from the incident table.
+
+while (grIncidentAge.next()) {
+//The while loop iterates over each record returned by the query. The next() method moves to the next record in the result set.
+
+var incCreated = new GlideDateTime(grIncidentAge.sys_created_on);
+//A new GlideDateTime object is created using the sys_created_on field of the current incident record. This field stores the date and time when the incident was created.
+
+var nowDT = new GlideDateTime();
+//Another GlideDateTime object is created that contains the current date and time.
+
+var ageInMilliseconds = nowDT.getNumericValue() - incCreated.getNumericValue();
+//The numeric values of the current and created dates are obtained, and the difference is calculated to find the age of the incident in milliseconds.
+
+var ageInDays = Math.floor(ageInMilliseconds / (1000 * 60 * 60 * 24));
+//The age in milliseconds is converted to days by dividing by the number of milliseconds in a day (1,000 milliseconds/second * 60 seconds/minute * 60 minutes/hour * 24 hours/day). The result is rounded down using Math.floor().

--- a/Background Scripts/findTableSize.js
+++ b/Background Scripts/findTableSize.js
@@ -1,0 +1,11 @@
+var table_name = 'sys_attachment_doc'; //The file data of attachment is stored in this Table in ServiceNow
+
+var tabSizeinGB = new GlideRecord('sys_physical_table_stats');
+tabSizeinGB.addQuery('table_name', table_name); //Querying with the 'sys_attachment_doc' table to get the size of it
+tabSizeinGB.setLimit(1); //This will limit to one record query
+tabSizeinGB.query();
+if (tabSizeinGB.next()) {
+    gs.info('[' + tabSizeinGB.getValue('table_name') +']' + ' table Size is: ' + tabSizeinGB.getValue('table_size_in_gb') + ' GB');
+} else {
+    gs.info('Table not found!');
+}


### PR DESCRIPTION
This script calculates and logs the age of all incidents in the ServiceNow incident table. It retrieves each incident's creation date, compares it with the current date, and calculates the age in days. This approach is useful for monitoring how long incidents have been open, helping teams prioritize older issues and ensuring timely resolution.