### PR TITLE
Reject the ritm via fix script

### DIFF
--- a/Fix scripts/Reject RITM via fix script/README.md
+++ b/Fix scripts/Reject RITM via fix script/README.md
@@ -1,0 +1,2 @@
+This fix script helps to reject the RITM in a scenario where workflow not triggered properly, so we can use this script manually to reject the RITM.
+Recently I also landed up into the same situation where workflow not able to the reject the RITM so at that point of time this script was a life saver to without having any business impact.

--- a/Fix scripts/Reject RITM via fix script/Reject RITM.js
+++ b/Fix scripts/Reject RITM via fix script/Reject RITM.js
@@ -3,13 +3,13 @@ item.addQuery("sys_id","31cd7552db252200a6a2b31be0b8f55c"); // sys_id of the RIT
 item.query();
 if(item.next()){
   var approval = new GlideRecord("sysapproval_approver");
-  Approval.addQuery("document_id",item.getUniqueValue(); // Get the sys_Id of document Id field on approval table
-  Approval.query();
-  if(Approval.next()){
-    Approval.state="Rejected";
+  approval.addQuery("document_id",item.getUniqueValue()); // Get the sys_Id of document Id field on approval table
+  approval.query();
+  if(approval.next()){
+    approval.state="Rejected";
     item.apprpval="Rejected";
   }
   item.setWorkflow(false);
   item.update();
-  Approval.update(); // Update the record on approval table.
+  approval.update(); // Update the record on approval table.
 }

--- a/Fix scripts/Reject RITM via fix script/Reject RITM.js
+++ b/Fix scripts/Reject RITM via fix script/Reject RITM.js
@@ -1,0 +1,15 @@
+var item = new GlideRecord("sc_req_item");
+item.addQuery("sys_id","31cd7552db252200a6a2b31be0b8f55c"); // sys_id of the RITM
+item.query();
+if(item.next()){
+  var approval = new GlideRecord("sysapproval_approver");
+  Approval.addQuery("document_id",item.getUniqueValue(); // Get the sys_Id of document Id field on approval table
+  Approval.query();
+  if(Approval.next()){
+    Approval.state="Rejected";
+    item.apprpval="Rejected";
+  }
+  item.setWorkflow(false);
+  item.update();
+  Approval.update(); // Update the record on approval table.
+}


### PR DESCRIPTION
This fix script helps to reject the RITM manually without impacting any other OOTB functionality. If in case where work flow not get triggered properly.