### PR TITLE
Code to display on-call calendar for the respective assignment group

### DIFF
--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -8,3 +8,5 @@ This code provides a Jelly script UI Macros to display an on-call schedule butto
 - Constructs a URL with proper encoding to navigate to the on-call workbench.
 
 I have used this code on the Incident Table 
+
+

--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -1,0 +1,10 @@
+# Displaying On-Call Schedule or Calendar next to the assignment group
+
+This code provides a Jelly script UI Macros to display an on-call schedule button in ServiceNow table. It allows users to view the on-call schedule for a specific group by generating a URL to the on-call workbench.
+
+## Features
+- Generates a button in ServiceNow that opens the on-call schedule for a selected group.
+- Uses GlideRecord to check for active on-call rotations.
+- Constructs a URL with proper encoding to navigate to the on-call workbench.
+
+I have used this code in the Incident Table 

--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -7,4 +7,4 @@ This code provides a Jelly script UI Macros to display an on-call schedule butto
 - Uses GlideRecord to check for active on-call rotations.
 - Constructs a URL with proper encoding to navigate to the on-call workbench.
 
-I have used this code in the Incident Table 
+I have used this code on the Incident Table 

--- a/On-Call Calendar/show_group_on_call_schedule.js
+++ b/On-Call Calendar/show_group_on_call_schedule.js
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<j:jelly trim="false" xmlns:j="jelly:core" xmlns:g="glide" xmlns:j2="null" xmlns:g2="null">
+    <g:evaluate var="jvar_guid" expression="gs.generateGUID(this);" />
+    <j:set var="jvar_n" value="show_schedule_${jvar_guid}:${ref}"/>
+    <g:reference_decoration id="${jvar_n}" field="${ref}"
+        onclick="showOnCallSchedule('${jvar_n}')"
+        title="${gs.getMessage('Show group on-call schedule')}" image="images/icons/tasks.gifx" icon="icon-calendar"/>
+    <script>
+        function showOnCallSchedule(reference){
+            var group = g_form.getValue(reference.split('.')[1]);
+            var grpRota = new GlideRecord('cmn_rota');
+            grpRota.addQuery('group', group);
+            grpRota.addQuery('active', true);
+            grpRota.query();
+            if(grpRota.hasNext()){
+                // Get the sys_id (assuming you have a method to retrieve the correct sys_id)
+                var sysId = '3D' + group; // Ensure the sys_id starts with "3D"
+                // Construct a URL for the popup window using $[AMP]
+                var url = 'https://instancename.service-now.com/now/nav/ui/classic/params/target/%24oc_workbench.do%3Fsysparm_redirect%3D%2524oc_groups.do$[AMP]sysparm_group_id%3D' + encodeURIComponent(group);
+                // Open the popup
+                popupOpenStandard(url);
+            } else {
+                alert('No active rotation specified for the selected group.');
+            }
+        }
+    </script>
+</j:jelly>


### PR DESCRIPTION
# ServiceNow On-Call Calendar UI Macro

This snippet provides a UI Macro Jelly script to display an on-call calendar for the respective assignment group in ServiceNow. This functionality allows users to easily access the on-call schedule for specific groups. I have used this in our organization on the Incident table.

## Features
- Generates a button within the ServiceNow UI that opens the on-call calendar for a selected assignment group.
- Utilizes GlideRecord to check for active on-call rotations.

## Note
The following line in the code is not required and can be ignored: 

var sysId = '3D' + group;
