### PR TITLE
Enforce File Upload Restrictions for HR Document Submission

### DIFF
--- a/Business Rules/Enforce File Upload Restrictions for HR Document Submission /Code.js
+++ b/Business Rules/Enforce File Upload Restrictions for HR Document Submission /Code.js
@@ -1,0 +1,24 @@
+var hrTask = new GlideRecord('sn_hr_core_task');
+
+if (hrTask.get(current.table_sys_id) && 
+    hrTask.hr_Task_type == 'upload_documents' && 
+    hrTask.short_description == 'submit photo identification') {
+
+    var fileName = current.file_name.toString();
+    var fileSize = current.size_bytes.toString();
+    var fileType = fileName.split('.').pop().toLowerCase();
+
+    // Check file size (must not exceed 2MB)
+    if (parseInt(fileSize) > 2000000) { // 2MB in bytes
+        gs.addErrorMessage('Maximum file size is 2 MB');
+        current.setAbortAction(true); // Abort if file size exceeds 2 MB
+        return;
+    }
+
+    // Check file type (must be JPG or JPEG)
+    if (fileType !== 'jpg' && fileType !== 'jpeg') {
+        gs.addErrorMessage('File must be in JPG or JPEG format');
+        current.setAbortAction(true); // Abort if not JPG or JPEG
+        return;
+    }
+        }

--- a/Business Rules/Enforce File Upload Restrictions for HR Document Submission /Readme.md
+++ b/Business Rules/Enforce File Upload Restrictions for HR Document Submission /Readme.md
@@ -1,0 +1,4 @@
+This code ensures that when a user uploads a document related to a specific HR task, the uploaded file meets
+certain criteria: it must be in JPG or JPEG format and must not exceed 2 MB in size. If either condition is violated,
+the upload is halted, and an appropriate error message is displayed to the user, maintaining the integrity of the data 
+being processed.


### PR DESCRIPTION
This code verifies that any document uploaded for a specific HR task adheres to defined criteria: it must be in JPG or JPEG format and cannot exceed 2 MB in size. If either requirement is not met, the upload is stopped, and a relevant error message is presented to the user, ensuring data integrity during the process