### PR TITLE
Finding groups with Inactive Managers

### DIFF
--- a/Background Scripts/Finding groups with inactive managers.js
+++ b/Background Scripts/Finding groups with inactive managers.js
@@ -1,0 +1,15 @@
+function Checkgrps() {
+    var arr = []; //empty arr
+    var gr = new GlideRecord("sys_user_group"); //querying group table
+    gr.addActiveQuery(); //filtering only active groups
+    gr.query();
+    while (gr.next()) {
+        if (gr.manager.active == false || gr.manager.nil()) { //dot-walking to check manager's active status and also checking if the group does'nt have a manager assigned or not
+            arr.push(gr.name.toString() + " "); //pushing all the group names into an array
+        }
+    }
+    gs.info("Groups with inactive or no manager: " + arr); //
+    return arr; //returns the arr with all the group names
+}
+
+Checkgrps(); //calling the function to execute the script

--- a/Background Scripts/readme.md
+++ b/Background Scripts/readme.md
@@ -1,0 +1,8 @@
+This script is designed to identify all active user groups in ServiceNow where:
+	The group has no manager assigned, OR
+	The assigned manager is inactive.
+This script helps administrators easily locate and notify the management about this inconsistancy.
+
+Administrators can also use this script in their fix scripts and add a mailing functionality to the group members by calling an event to trigger the mail.
+
+All you need to do is use the call the function : "Checkgrps()" and it will check for the groups with inactive or no managers and stores the names of the groups in an array "arr".


### PR DESCRIPTION
This script is designed to identify all active user groups in ServiceNow where: -->The group has no manager assigned, OR
-->The assigned manager is inactive.
and store the names of the found groups in an array "arr" which can utilized later.