### PR TITLE
Cancel in progress flow executions using flow name

### DIFF
--- a/Fix scripts/Cancel in progress flow executions using flow name/readme.md
+++ b/Fix scripts/Cancel in progress flow executions using flow name/readme.md
@@ -1,0 +1,7 @@
+The script in Fix scripts > Cancel in progress flow executions using flow name > script.js can be used to cancel the dlow executions using the name of the flow you have provided.
+
+This can be used to cancel huge amount of flow executions created for testing.
+
+This can also be used to cancel all the defective flow executions in one go.
+
+Replace "NAME OF FLOW TO CANCEL HERE" with the name of the flow which you need to cancel

--- a/Fix scripts/Cancel in progress flow executions using flow name/script.js
+++ b/Fix scripts/Cancel in progress flow executions using flow name/script.js
@@ -1,0 +1,6 @@
+var gr = new GlideRecord("sys_flow_context"); 
+gr.addQuery("name", "NAME OF FLOW TO CANCEL HERE"); //Replace "NAME OF FLOW TO CANCEL HERE" with the name of the flow which you need to cancel
+gr.query(); 
+while (gr.next()) { 
+sn_fd.FlowAPI.cancel(gr.getUniqueValue(), 'Canceling In progress Flows'); 
+} 


### PR DESCRIPTION
The script in Fix scripts > Cancel in progress flow executions using flow name > script.js can be used to cancel the flow executions using the name of the flow you have provided.

This can be used to cancel huge amount of flow executions created for testing.

This can also be used to cancel all the defective flow executions in one go.

Replace "NAME OF FLOW TO CANCEL HERE" with the name of the flow which you need to cancel