### PR TITLE
Background Script to calculate the Age of the tickets

### DIFF
--- a/Background Scripts/Calculate Ticket Age/Background Script to calculate the Age of the tickets.js
+++ b/Background Scripts/Calculate Ticket Age/Background Script to calculate the Age of the tickets.js
@@ -1,0 +1,14 @@
+var gr = new GlideRecord('incident');
+gr.addEncodedQuery('state!=7^state!=8'); // Removed redundant checks for NULL states
+gr.query();
+while (gr.next()) {
+    var createdDate = gr.sys_created_on; // 2019-01-11 17:18:53
+    var extractedDate = createdDate.getGlideObject(); // Use GlideDateTime to work with dates
+    var todayDate = new GlideDateTime(); // Current date and time
+    var ticketAge = todayDate.getNumericValue() - extractedDate.getNumericValue(); // Get age in milliseconds
+    
+    // Convert age from milliseconds to days
+    var ticketAgeDays = Math.floor(ticketAge / (1000 * 60 * 60 * 24)); 
+    gs.print('The age of the ticket ' + gr.number + ' is: ' + ticketAgeDays + ' days');
+}
+

--- a/Background Scripts/Calculate Ticket Age/README.md
+++ b/Background Scripts/Calculate Ticket Age/README.md
@@ -1,0 +1,27 @@
+# Calculate Ticket Age Script
+
+## Overview
+This script retrieves incidents from the ServiceNow `incident` table that are neither resolved nor closed. It calculates the age of each ticket in days based on the creation date and prints the result.
+
+## Purpose
+The primary purpose of this script is to help Administrators / Developers identify how long tickets have been open. This can assist in prioritizing issues that need attention and improving overall incident management.
+
+## How It Works
+1. **Query the Incident Table**: The script queries the `incident` table, filtering out tickets that are in the "Resolved" (state 7) and "Closed" (state 8) states.
+2. **Calculate Age**: For each incident, it calculates the age in days by comparing the current date with the ticket's creation date.
+3. **Output**: The age of each ticket is printed to the system logs.
+
+## Script Breakdown
+- **GlideRecord**: Used to query the `incident` table.
+- **GlideDateTime**: Used to manipulate date and time values for accurate calculations.
+- **gs.print()**: Outputs the ticket age to the system logs.
+
+## Usage
+To use this script:
+1. Copy the script into your ServiceNow Background Script Editor.
+2. Run the script.
+3. View the output
+
+## Note
+This script can be modified for any tables by changing the GlideRecord target and adapting the filter conditions as needed.
+

--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -8,3 +8,5 @@ This code provides a Jelly script UI Macros to display an on-call schedule butto
 - Constructs a URL with proper encoding to navigate to the on-call workbench.
 
 I have used this code on the Incident Table 
+
+

--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -1,0 +1,10 @@
+# Displaying On-Call Schedule or Calendar next to the assignment group
+
+This code provides a Jelly script UI Macros to display an on-call schedule button in ServiceNow table. It allows users to view the on-call schedule for a specific group by generating a URL to the on-call workbench.
+
+## Features
+- Generates a button in ServiceNow that opens the on-call schedule for a selected group.
+- Uses GlideRecord to check for active on-call rotations.
+- Constructs a URL with proper encoding to navigate to the on-call workbench.
+
+I have used this code in the Incident Table 

--- a/On-Call Calendar/README.md
+++ b/On-Call Calendar/README.md
@@ -7,4 +7,4 @@ This code provides a Jelly script UI Macros to display an on-call schedule butto
 - Uses GlideRecord to check for active on-call rotations.
 - Constructs a URL with proper encoding to navigate to the on-call workbench.
 
-I have used this code in the Incident Table 
+I have used this code on the Incident Table 

--- a/On-Call Calendar/show_group_on_call_schedule.js
+++ b/On-Call Calendar/show_group_on_call_schedule.js
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<j:jelly trim="false" xmlns:j="jelly:core" xmlns:g="glide" xmlns:j2="null" xmlns:g2="null">
+    <g:evaluate var="jvar_guid" expression="gs.generateGUID(this);" />
+    <j:set var="jvar_n" value="show_schedule_${jvar_guid}:${ref}"/>
+    <g:reference_decoration id="${jvar_n}" field="${ref}"
+        onclick="showOnCallSchedule('${jvar_n}')"
+        title="${gs.getMessage('Show group on-call schedule')}" image="images/icons/tasks.gifx" icon="icon-calendar"/>
+    <script>
+        function showOnCallSchedule(reference){
+            var group = g_form.getValue(reference.split('.')[1]);
+            var grpRota = new GlideRecord('cmn_rota');
+            grpRota.addQuery('group', group);
+            grpRota.addQuery('active', true);
+            grpRota.query();
+            if(grpRota.hasNext()){
+                // Get the sys_id (assuming you have a method to retrieve the correct sys_id)
+                var sysId = '3D' + group; // Ensure the sys_id starts with "3D"
+                // Construct a URL for the popup window using $[AMP]
+                var url = 'https://instancename.service-now.com/now/nav/ui/classic/params/target/%24oc_workbench.do%3Fsysparm_redirect%3D%2524oc_groups.do$[AMP]sysparm_group_id%3D' + encodeURIComponent(group);
+                // Open the popup
+                popupOpenStandard(url);
+            } else {
+                alert('No active rotation specified for the selected group.');
+            }
+        }
+    </script>
+</j:jelly>


### PR DESCRIPTION
# Calculate Ticket Age Script

## Overview
This script retrieves incidents from the ServiceNow `incident` table that are neither resolved nor closed. It calculates the age of each ticket in days based on the creation date and prints the result.

## Purpose
The primary purpose of this script is to help administrators identify how long tickets have been open. This can assist in prioritizing issues that need attention and improving overall incident management.

## How It Works
1. **Query the Incident Table**: The script queries the `incident` table, filtering out tickets that are in the "Resolved" (state 7) and "Closed" (state 8) states.
2. **Calculate Age**: For each incident, it calculates the age in days by comparing the current date with the ticket's creation date.
3. **Output**: The age of each ticket is printed on the screen.

## Script Breakdown
- **GlideRecord**: Used to query the `incident` table.
- **GlideDateTime**: Used to manipulate date and time values for accurate calculations.
- **gs.print()**: Outputs the ticket age to the system logs.

## Usage
To use this script:
1. Copy the script into your ServiceNow Background Script Editor.
2. Run the script.
3. View the output.

## Note
This script can be modified for any tables by changing the GlideRecord target and adapting the filter conditions as needed.



