### PR TITLE
Capturing a record in to the current update set using background script

### DIFF
--- a/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
+++ b/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
@@ -1,0 +1,4 @@
+var gr = new GlideRecord('<table_name>');//in <table_name> provide the table name in which the record is present
+gr.get('<sys_id of the record>');//in <sys_id of the record> provide the sys_id of the record which you need to capture in the update set
+var gum = new GlideUpdateManager2();
+gum.saveRecord(gr);

--- a/Background Scripts/Capturing a record in to the current update set/readme.md
+++ b/Background Scripts/Capturing a record in to the current update set/readme.md
@@ -1,0 +1,3 @@
+Using this script present in "Capturing a record in to the current update set using background script.js" file we can capture a record from a table (eg; groups, approval configurations) to the current update set
+
+We have to provide the table name and the sys_id of the record properly as mentioned in the script.


### PR DESCRIPTION
Using the script present in "Capturing a record in to the current update set using background script.js" file we can capture a record from a table (eg; groups, approval configurations) to the current update set

We have to provide the table name and the sys_id of the record properly as mentioned in the script.