### PR TITLE
Capturing a record in to the current update set using background script

### DIFF
--- a/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
+++ b/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
@@ -1,4 +1,4 @@
 var gr = new GlideRecord('<table_name>');//in <table_name> provide the table name in which the record is present
 gr.get('<sys_id of the record>');//in <sys_id of the record> provide the sys_id of the record which you need to capture in the update set
-var gum = new GlideUpdateManager2();
+var gum = new GlideUpdateManager2(); //more details on GlideUpdateManager2 API is provided in the readme.md file
 gum.saveRecord(gr);

--- a/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
+++ b/Background Scripts/Capturing a record in to the current update set/Capturing a record in to the current update set using background script.js
@@ -1,0 +1,4 @@
+var gr = new GlideRecord('<table_name>');//in <table_name> provide the table name in which the record is present
+gr.get('<sys_id of the record>');//in <sys_id of the record> provide the sys_id of the record which you need to capture in the update set
+var gum = new GlideUpdateManager2();
+gum.saveRecord(gr);

--- a/Background Scripts/Capturing a record in to the current update set/readme.md
+++ b/Background Scripts/Capturing a record in to the current update set/readme.md
@@ -1,0 +1,3 @@
+Using this script present in "Capturing a record in to the current update set using background script.js" file we can capture a record from a table (eg; groups, approval configurations) to the current update set
+
+We have to provide the table name and the sys_id of the record properly as mentioned in the script.

--- a/Background Scripts/Capturing a record in to the current update set/readme.md
+++ b/Background Scripts/Capturing a record in to the current update set/readme.md
@@ -1,3 +1,9 @@
 Using this script present in "Capturing a record in to the current update set using background script.js" file we can capture a record from a table (eg; groups, approval configurations) to the current update set
 
 We have to provide the table name and the sys_id of the record properly as mentioned in the script.
+
+When using the GlideUpdateManager2 API, a record is created in the sys_update_version table, and an XML file is created under the customer update folder because it is a part of the mechanism that allows adding records to an update set.
+
+GlideUpdateManager2() will only work in global scope. If you try to create an update sect in scoped application and try to use GlideUpdateManager2 API then it will capture the update in the crrent scoped update set but the update will be in global scope. So there will be conflict while moving the update set.
+
+Note: GlideUpdateManager2 API is undocumented API.


### PR DESCRIPTION
Using this script present in "Capturing a record in to the current update set using background script.js" file we can capture a record from a table (eg; groups, approval configurations) to the current update set

We have to provide the table name and the sys_id of the record properly as mentioned in the script.

When using the GlideUpdateManager2 API, a record is created in the sys_update_version table, and an XML file is created under the customer update folder because it is a part of the mechanism that allows adding records to an update set.

GlideUpdateManager2() will only work in global scope. If you try to create an update sect in scoped application and try to use GlideUpdateManager2 API then it will capture the update in the crrent scoped update set but the update will be in global scope. So there will be conflict while moving the update set.

Note: GlideUpdateManager2 API is undocumented API.