### PR TITLE
Adding bookmark to favorites tab

### DIFF
--- a/Background Scripts/Adding bookmark to Favorites tab/Adding bookmark into Favorites tab.js
+++ b/Background Scripts/Adding bookmark to Favorites tab/Adding bookmark into Favorites tab.js
@@ -1,0 +1,28 @@
+var memGroups = []; // empty array for getting the group sys'id rin future.
+var gr = new GlideRecord("sys_user_grmember");
+gr.addQuery("user", gs.getUserID()); //querying grmember table with the logged-in user to get user's groups.
+//gs.print("query is "+gr.getEncodedQuery());
+gr.query();
+while (gr.next()) {
+    memGroups.push(gr.group);//pushing the group's sys_id's into the array
+}
+//gs.print("groups "+memGroups.join(","));
+
+var filter = "assignment_groupIN" + memGroups.join(", ");// creating filter using the groups array
+
+var listURL = "/incident_list.do?sysparm_query=" + encodeURIComponent(filter); //creating the url with the filter to showcase the list of tickets assigned to the groups which the user is a part of.
+
+var bookmark = new GlideRecord("sys_ui_bookmark"); //gliding bookmark table to verify the logged-in user's has already a book mark or not 
+bookmark.addQuery("user", gs.getUserID());
+bookmark.addQuery("url", listURL);
+bookmark.query();
+if (!bookmark.next()) { //if not available then we are creating a new bookmark under favorites tab of the logged-in users
+    var newBookmark = new GlideRecord("sys_ui_bookmark");
+    newBookmark.initialize();
+	newBookmark.order
+    newBookmark.user = gs.getUserID();
+    newBookmark.url = listURL;
+    newBookmark.title = "Incidents assigned to my groups";
+    newBookmark.pinned = true;
+    newBookmark.insert();
+}

--- a/Background Scripts/Adding bookmark to Favorites tab/Adding bookmark into Favorites tab.js
+++ b/Background Scripts/Adding bookmark to Favorites tab/Adding bookmark into Favorites tab.js
@@ -1,14 +1,4 @@
-var memGroups = []; // empty array for getting the group sys'id rin future.
-var gr = new GlideRecord("sys_user_grmember");
-gr.addQuery("user", gs.getUserID()); //querying grmember table with the logged-in user to get user's groups.
-//gs.print("query is "+gr.getEncodedQuery());
-gr.query();
-while (gr.next()) {
-    memGroups.push(gr.group);//pushing the group's sys_id's into the array
-}
-//gs.print("groups "+memGroups.join(","));
-
-var filter = "assignment_groupIN" + memGroups.join(", ");// creating filter using the groups array
+var filter = "active=true^assignment_groupDYNAMICd6435e965f510100a9ad2572f2b47744";// using dynamic filter we are filtering the assignments groups of the logged-in user
 
 var listURL = "/incident_list.do?sysparm_query=" + encodeURIComponent(filter); //creating the url with the filter to showcase the list of tickets assigned to the groups which the user is a part of.
 
@@ -18,11 +8,12 @@ bookmark.addQuery("url", listURL);
 bookmark.query();
 if (!bookmark.next()) { //if not available then we are creating a new bookmark under favorites tab of the logged-in users
     var newBookmark = new GlideRecord("sys_ui_bookmark");
-    newBookmark.initialize();
-	newBookmark.order
-    newBookmark.user = gs.getUserID();
-    newBookmark.url = listURL;
-    newBookmark.title = "Incidents assigned to my groups";
-    newBookmark.pinned = true;
-    newBookmark.insert();
+	newBookmark.initialize();
+	newBookmark.order=9;
+	newBookmark.icon="list";
+	newBookmark.user = gs.getUserID();
+	newBookmark.url = listURL;
+	newBookmark.title = "Incidents assigned to my groups";
+    	newBookmark.pinned = true;
+    	newBookmark.insert();
 }

--- a/Background Scripts/Adding bookmark to Favorites tab/readme.md
+++ b/Background Scripts/Adding bookmark to Favorites tab/readme.md
@@ -1,7 +1,6 @@
 The script bookmarks the list of incidents assigned to the user's groups in ServiceNow's favorite tab. It works by :
-
---> Fetching the logged-in user's group memberships.  
---> Constructing a filter for incidents assigned to those groups.  
+  
+--> Constructing a filter for incidents assigned to logged-in user's groups using the OOTB dynamic filter functionality.  
 --> Checking if the list is already bookmarked.  
 --> If not, it creates a new bookmark with the title : "Incidents assigned to my groups", adds the list url.  
 

--- a/Background Scripts/Adding bookmark to Favorites tab/readme.md
+++ b/Background Scripts/Adding bookmark to Favorites tab/readme.md
@@ -1,0 +1,8 @@
+The script bookmarks the list of incidents assigned to the user's groups in ServiceNow's favorite tab. It works by :
+
+--> Fetching the logged-in user's group memberships.  
+--> Constructing a filter for incidents assigned to those groups.  
+--> Checking if the list is already bookmarked.  
+--> If not, it creates a new bookmark with the title : "Incidents assigned to my groups", adds the list url.  
+
+This allows the user to quickly access the list of relevant incidents from the favorites tab.	 


### PR DESCRIPTION
The script is designed to bookmark the list of incidents assigned to the user's groups in ServiceNow's favorite tab if not already present.