### PR TITLE
fix: Get URL Parameters

### DIFF
--- a/Client Scripts/Get URL Parameters/script.js
+++ b/Client Scripts/Get URL Parameters/script.js
@@ -1,15 +1,14 @@
 function onLoad() {
-//Type appropriate comment here, and begin script below
+    //Type appropriate comment here, and begin script below
 
-if(window == null){ // For Service Portal
-var url = top.location.href;
-var value = new URLSearchParams(url).get('sysparm_id'); //provide the parameter name
-console.log(value);
-}
-else{ //For Native UI
-var glideURL = new GlideURL();
-glideURL.setFromCurrent();
-var id = glideURL.getParam("sysparm_id"); // provide the parameter name
-console.log(id);
-}
+    if (typeof spModal != "undefined") { // For Service Portal
+        var url = top.location.href;
+        var value = new URLSearchParams(url).get("sys_id"); //provide the parameter name
+        console.log(value);
+    } else { //For Native UI
+        var glideURL = new GlideURL();
+        glideURL.setFromCurrent();
+        var id = glideURL.getParam("sysparm_id"); // provide the parameter name
+        console.log(id);
+    }
 }


### PR DESCRIPTION
Refactor - Indenting And Whitespace

Replace check for window object with check for spModal object,
which is available in Service Portal only.

Update URLSearchParam from sysparm_id to sys_id.

Resolves #416
