### PR TITLE
Get encoded query in readable format

### DIFF
--- a/Background Scripts/Read Encoded Query/readQuery.js
+++ b/Background Scripts/Read Encoded Query/readQuery.js
@@ -1,0 +1,5 @@
+// This code get the encoded query in readable format.
+// Copy and paste encoded query in quotes of the function API whoch you want to read.
+
+var grQ= new GlideQueryBreadcrumbs().getReadableQuery('');
+gs.info("Readable Query is "+grQ);

--- a/Background Scripts/Read Encoded Query/readQuery.js
+++ b/Background Scripts/Read Encoded Query/readQuery.js
@@ -1,5 +1,5 @@
 // This code get the encoded query in readable format.
-// Copy and paste encoded query in quotes of the function API whoch you want to read.
+// Pass the table name and encoded query in the function API whoch you want to read.
 
-var grQ= new GlideQueryBreadcrumbs().getReadableQuery('');
+var grQ= new GlideQueryBreadcrumbs().getReadableQuery('table name', 'Pass the encoded query');
 gs.info("Readable Query is "+grQ);

--- a/Background Scripts/Read Encoded Query/readme.md
+++ b/Background Scripts/Read Encoded Query/readme.md
@@ -1,0 +1,17 @@
+This background script code to get the any encoded query in redable format.
+You need to paste the encoded query in the quotes of the function API which you want to read in simple layman format 
+
+Input Required as below
+
+1. Table name on which the query is.
+2. Any encoded query which you want to read
+
+   Input Eg.
+
+   Table Name- incident
+   Encoded query  - 'active=true^short_descriptionLIKEtest'
+
+   Output- Readable Query is Active = true .and. Short description contains test
+
+
+   Please note that this API is allowed to worked in global application. It is not applicable in scoped application.


### PR DESCRIPTION
This background script from Pull request is used to get the any encoded query in readable format.