### PR TITLE
Get all ci classes present in the ServiceNow instance

### DIFF
--- a/Background Scripts/Get All the CI classes/getAllCiClasses.js
+++ b/Background Scripts/Get All the CI classes/getAllCiClasses.js
@@ -1,0 +1,5 @@
+// Find all CI Classes
+var table = new TableUtils("cmdb_ci");
+var ciTableList = j2js(table.getAllExtensions());
+for (var i = 0; i < ciTableList.length; i++) 
+gs.print(ciTableList[i]);

--- a/Background Scripts/Get All the CI classes/readme.md
+++ b/Background Scripts/Get All the CI classes/readme.md
@@ -1,0 +1,1 @@
+This background script provides the names of all the available Ci classes present in the system


### PR DESCRIPTION
This background script contains this Pull Request provides the names of all the available Ci classes present in the system.