### PR TITLE
Pull empty serial number asset records

### DIFF
--- a/Script Includes/PullEmptySerialNumberAssetRecords/pull_empty_serial_number_record.js
+++ b/Script Includes/PullEmptySerialNumberAssetRecords/pull_empty_serial_number_record.js
@@ -1,0 +1,39 @@
+var getAssetRecord = Class.create();
+getAssetRecord.prototype = {
+    initialize: function() {},
+	
+   assetRecord: function() {
+        try { 
+			var tableName= "alm_asset";
+            var result = [];
+            var ruleDescription = "Records in Asset with missing Serial Number";
+
+            // GlideRecord query to get all assets with missing Serial Number
+            var grAsset = new GlideRecordSecure(tableName);
+            grAsset.addEncodedQuery('serial_numberEMPTY'); // Checking for missing serial numbers
+            grAsset.query();
+
+            var count = grAsset.getRowCount(); // Count of records with missing serial numbers
+
+            // Get the instance URL
+            var instanceUrl = gs.getProperty('glide.servlet.uri'); // Get the instance's base URL
+            var url = instanceUrl + 'alm_asset_list.do?sysparm_query=serial_numberEMPTY'; // Complete URL for assets with missing serial number
+
+            // Create the object with required fields and push to result array
+            result.push({
+                ruleDescription: ruleDescription,
+                count: count,
+                tableName: tableName,
+                url: url
+            });
+
+            // Return the result as a JSON string
+            return JSON.stringify(result);
+        } catch (e) {
+            // Log the error in case something goes wrong
+            var message = 'In INHUB_0198 method, failure could be due to ' + e.message;
+            return ["Error", message];
+        }
+    },
+    type: 'getAssetRecord'
+};

--- a/Script Includes/PullEmptySerialNumberAssetRecords/readme.md
+++ b/Script Includes/PullEmptySerialNumberAssetRecords/readme.md
@@ -1,0 +1,51 @@
+Overview
+The getAssetRecord Script Include is designed to identify records in the alm_asset table that are missing a serial_number. This functionality is crucial for maintaining the integrity of asset management data, as it ensures that all assets have complete and accurate information. The script executes a query to detect assets with a missing serial_number and returns a summary that includes the count of such records and a direct link to view them in the ServiceNow interface.
+
+How It Works
+Initialization:
+
+The script defines the assetRecord() method, which is responsible for executing the logic to find asset records with missing serial_number.
+Query Execution:
+
+A GlideRecordSecure object is created to query the alm_asset table.
+An encoded query is added using addEncodedQuery('serial_numberEMPTY'), which checks for records where the serial_number field is empty.
+Result Compilation:
+
+The script counts the number of records that match the query using getRowCount().
+The instance's base URL is retrieved using gs.getProperty('glide.servlet.uri'), which is used to construct a complete URL to view the filtered list of records.
+An object containing the rule description, count of missing serial numbers, table name, and URL is created and pushed to the result array.
+Output:
+
+The method returns the result array as a JSON string, which includes:
+ruleDescription: Describes the purpose of the query.
+count: Number of assets with missing serial numbers.
+tableName: Identifies the alm_asset table.
+url: A link to the ServiceNow list view filtered for these records.
+Testing
+Unit Testing:
+
+You can test the script by executing it in the Scripts - Background module in ServiceNow.
+To run a test, enter the following code in the background script editor:
+javascript
+Copy code
+var assetScriptInclude = new getAssetRecord();
+var result = assetScriptInclude.assetRecord();
+gs.info('Result from assetRecord: ' + result);
+After executing the script, check the logs under System Logs > All to review the output.
+Integration Testing:
+
+Integrate this Script Include into other ServiceNow processes, such as scheduled jobs or business rules, to automate the detection of assets with missing serial_number.
+Monitor the output to ensure it meets expectations when invoked under various conditions.
+Benefits
+Automated Data Validation:
+
+This Script Include automates the detection of assets with incomplete information, significantly reducing manual checks and improving efficiency.
+Actionable Insights:
+
+The output includes a direct URL to the affected records, allowing asset managers and IT staff to quickly navigate to the relevant data for review and remediation.
+Improved Data Integrity:
+
+Regular use of this script helps maintain high data quality in the asset management system, reducing the risk of compliance issues or operational inefficiencies.
+Enhanced Reporting:
+
+By identifying assets without a serial_number, organizations can generate accurate reports and make informed decisions regarding asset management and inventory control.


### PR DESCRIPTION
The getAssetRecord Script Include is designed to identify records in the alm_asset table that are missing a serial_number. This functionality is crucial for maintaining the integrity of asset management data, as it ensures that all assets have complete and accurate information, you can use same script include in many ways by changing the table name and the encoded query according to your requiremnt