### PR TITLE
UI page auto populate assigned to based on assignment group

### DIFF
--- a/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/client_script.js
+++ b/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/client_script.js
@@ -1,0 +1,13 @@
+function onAssignmentGroupChange(){
+	var assignGroup = gel('assignment_group').value;	
+	var ga = new GlideAjax('global.getGroupUserIDUtil');
+	ga.addParam('sysparm_name','getUserId');
+	ga.addParam('sysparm_group',assignGroup);
+	ga.getXML(handleXml);
+}
+
+function handleXml(response){
+	var userIDArr = response.responseXML.documentElement.getAttribute("answer");
+	var userLookUp = gel('lookup.assigned_to');
+	userLookUp.setAttribute('onclick',"mousePositionSave(event); reflistOpen( 'assigned_to', 'not', 'sys_user', '', 'false','QUERY:active=false','sys_idIN" + userIDArr+ "', '')");
+}

--- a/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/jelly_script.xml
+++ b/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/jelly_script.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<j:jelly trim="false" xmlns:j="jelly:core" xmlns:g="glide" xmlns:j2="null" xmlns:g2="null">
+<label>Assignment Group</label>
+<g:ui_reference id="assignment_group" name="assignment_group" table="sys_user_group" query="active=true" coloumns="label" onChange="onAssignmentGroupChange()"/>
+<label>Assigned To</label>
+<g:ui_reference id="assigned_to" name="assigned_to" table="sys_user" query="active=true" />
+</j:jelly>

--- a/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/readme.md
+++ b/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/readme.md
@@ -1,0 +1,35 @@
+This project adds functionality to dynamically filter the "Assigned To" field based on the selected "Assignment Group" on a UI page. When a group is selected, only users from that group will be displayed in the "Assigned To" reference field.
+
+Overview
+The UI page includes two reference fields:
+
+Assignment Group: A reference to the sys_user_group table where users can select an active group.
+Assigned To: A reference to the sys_user table that should display users belonging to the selected "Assignment Group."
+Solution Approach
+UI Page Setup: The "Assignment Group" field is configured to trigger a function when a group is selected. The "Assigned To" field is updated based on the selected group.
+
+Client-Side Script:
+
+The onAssignmentGroupChange() function is triggered when the "Assignment Group" field is changed. It retrieves the selected group's internal ID.
+A GlideAjax call is made to send the selected group ID to the server-side Script Include.
+Upon receiving a response, the script processes the data and updates the lookup filter of the "Assigned To" field to display only the users from the selected group.
+Server-Side Script (Script Include):
+
+A client-callable Script Include queries the sys_user_grmember table to retrieve user IDs of members in the selected group.
+The user IDs are returned to the client as a comma-separated string, which is used to update the "Assigned To" field's query.
+Key Steps
+onChange Trigger:
+
+The client script triggers whenever the "Assignment Group" field is updated by the user.
+GlideAjax Call:
+
+The onAssignmentGroupChange() function uses GlideAjax to send the selected group ID to the server-side Script Include.
+Retrieve Group Members:
+
+The Script Include queries the sys_user_grmember table to fetch user IDs for users in the selected group.
+Update the Lookup Field:
+
+The client script dynamically modifies the "Assigned To" field's lookup to filter users based on the selected "Assignment Group."
+Additional Notes
+Ensure that the Script Include is client-callable for it to be accessible via GlideAjax.
+This solution enhances user experience by restricting the "Assigned To" lookup field to relevant users from the selected "Assignment Group," improving data accuracy.

--- a/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/script_include.js
+++ b/UI Pages/UI Page Auto Populate Assigned to based on Assignment group/script_include.js
@@ -1,0 +1,16 @@
+var getGroupUserIDUtil = Class.create();
+getGroupUserIDUtil.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+
+	getUserId: function(){
+		var userIDArr = [];
+		var getGroup = this.getParameter('sysparm_group');
+		var getUser = new GlideRecord('sys_user_grmember');
+		getUser.addEncodedQuery('group='+getGroup);
+		getUser.query();
+		while(getUser.next()){
+			userIDArr.push(getUser.getValue('user'));
+		}
+		return userIDArr.join(',');
+	},
+    type: 'getGroupUserIDUtil'
+});


### PR DESCRIPTION
This pull implements a dynamic auto-population feature for the "Assigned To" field on a UI page, based on the selection made in the "Assignment Group" field. The "Assignment Group" references the sys_user_group table, and the "Assigned To" field references the sys_user table.

The goal is to filter the users displayed in the "Assigned To" field to only those who belong to the selected group. This functionality is achieved using a client-side script that triggers when the group is selected, sending the group information to a server-side Script Include via GlideAjax. The server-side logic retrieves the list of users in the group and returns them to the client, where the lookup for the "Assigned To" field is dynamically updated to reflect the filtered user list.

This solution improves usability by ensuring that only relevant users are selectable in the "Assigned To" field, enhancing data integrity and simplifying user selection.