### PR TITLE
Attach Report as PDF to Email.

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,5 +1,4 @@
 You can attach a report as PDF in email notification. To do that just add the following line to your body.
 
-$freport:reportID:YOUR_REPORT_SYS_ID)
-
+${report:reportID: YOUR_REPORT_SYS_ID }
 Replace YOUR_REPORT_SYS_ID with sys_ id of your report.

--- a/code.js
+++ b/code.js
@@ -1,0 +1,5 @@
+You can attach a report as PDF in email notification. To do that just add the following line to your body.
+
+$freport:reportID:YOUR_REPORT_SYS_ID)
+
+Replace YOUR_REPORT_SYS_ID with sys_ id of your report.


### PR DESCRIPTION
…cations by adding a specific line of code in the email body.

As a ServiceNow developer, one useful feature is the ability to automatically attach reports as PDFs to email notifications. This functionality is especially handy for sharing dynamic reports, ensuring recipients have the latest information in an easy-to-read format.

Create or Select a Report: First, ensure that the report you want to attach is already created in your instance.

Locate the Report's sys_id: Navigate to the report in ServiceNow and retrieve its unique sys_id. This can be found in the URL or by inspecting the record details.

Modify Email Notification: Open the email notification where you want to attach the report.

Add the Report Attachment Line: In the body of the email, add the following line:

${report:reportID: YOUR_REPORT_SYS_ID }
Replace YOUR_REPORT_SYS_ID with the sys_id of the report.

Save the Notification: Once the line is added and the report is referenced, save the email notification.

Now, whenever this email notification is triggered, the report will be attached as a PDF.