### PR TITLE
Slient Update on GlideRecord

### DIFF
--- a/Background Scripts/Slient update on GlideRecord/readme.md
+++ b/Background Scripts/Slient update on GlideRecord/readme.md
@@ -1,0 +1,1 @@
+Add the gr.autoSysFields(false) to prevent system updates when modifying GlideRecord in background script execution. This is to preserve audit containing the last known user modifications from ticket form.

--- a/Background Scripts/Slient update on GlideRecord/slientUpdateOnGlideRecord.js
+++ b/Background Scripts/Slient update on GlideRecord/slientUpdateOnGlideRecord.js
@@ -1,0 +1,7 @@
+//Update GlideRecord without modification to system fields
+var grInc = new GlideRecord('incident');
+if (grInc.get('62826bf03710200044e0bfc8bcbe5df9')) {
+grInc.active='false;
+grInc.autoSysFields(false); 
+grInc.update();
+}

--- a/Background Scripts/Slient update on GlideRecord/slientUpdateOnGlideRecord.js
+++ b/Background Scripts/Slient update on GlideRecord/slientUpdateOnGlideRecord.js
@@ -1,7 +1,7 @@
 //Update GlideRecord without modification to system fields
 var grInc = new GlideRecord('incident');
 if (grInc.get('62826bf03710200044e0bfc8bcbe5df9')) {
-grInc.active='false;
+grInc.active='false';
 grInc.autoSysFields(false); 
 grInc.update();
 }


### PR DESCRIPTION
Use of GlideRecordObject.autoSysFields(false) to silently update GlideRecord without system updates during background script run.