### PR TITLE
Custom Relationships - Instead of duplication attachments

### DIFF
--- a/Server Side/Custom Relationship/readme.md
+++ b/Server Side/Custom Relationship/readme.md
@@ -1,0 +1,3 @@
+Instead of duplicating attachment by use of GlideSysAttachment.copy() simplest approach is to create a relationship from System Definition >> Relationship & then display it as a Related list on required set of Tables were attachments are to be shown.
+
+So, for a case where attachments from REQ (sc_request) are to be on RITM (sc_req_item) table then a relationship as below would suffice.

--- a/Server Side/Custom Relationship/script.js
+++ b/Server Side/Custom Relationship/script.js
@@ -1,0 +1,12 @@
+(function refineQuery(current, parent) {
+
+    var queryString = "table_nameINsc_request^table_sys_idIN" + parent.getValue("request");
+    var gr = new GlideRecord("sc_req_item");
+    gr.addQuery("request", parent.getValue("request"));
+    gr.query();
+    while (gr.next()) {
+        queryString += "," + gr.sys_id.toString();
+    }
+    current.addEncodedQuery(queryString);
+
+})(current, parent);


### PR DESCRIPTION
Instead of duplicating attachment by use of GlideSysAttachment.copy() simplest approach is to create a relationship from System Definition >> Relationship & then display it as a Related list on required set of Tables were attachments are to be shown.

So, for a case where attachments from REQ (sc_request) are to be on RITM (sc_req_item) table then a relationship as below would suffice.