### PR TITLE
Bulk Role Assignment Based on Conditions

### DIFF
--- a/Background Scripts/Bulk Role Assignment Based on Conditions/readme.md
+++ b/Background Scripts/Bulk Role Assignment Based on Conditions/readme.md
@@ -1,0 +1,1 @@
+Description: This is a script that assigns roles to users in bulk based on specific conditions such as department,location or job title. This script can simplify the process of managing user roles and permissions. Use Case: Assign the 'itil' role to all users in the 'IT' department who are located in a specific region.

--- a/Background Scripts/Bulk Role Assignment Based on Conditions/script.js
+++ b/Background Scripts/Bulk Role Assignment Based on Conditions/script.js
@@ -1,0 +1,41 @@
+// Define the role to be assigned
+var roleName = 'itil';
+
+// Define the conditions for user selection
+var department = 'IT';
+var location = 'San Diego';
+
+// Fetch the role record
+var roleGR = new GlideRecord('sys_user_role');
+roleGR.addQuery('name', roleName);
+roleGR.query();
+if (!roleGR.next()) {
+    gs.error('Role not found: ' + roleName);
+    return;
+}
+
+// Fetch users matching the conditions
+var userGR = new GlideRecord('sys_user');
+userGR.addQuery('department.name', department);
+userGR.addQuery('location.name', location);
+userGR.query();
+
+var count = 0;
+while (userGR.next()) {
+    // Check if the user already has the role
+    var userRoleGR = new GlideRecord('sys_user_has_role');
+    userRoleGR.addQuery('user', userGR.sys_id);
+    userRoleGR.addQuery('role', roleGR.sys_id);
+    userRoleGR.query();
+    if (!userRoleGR.next()) {
+        // Assign the role to the user
+        var newUserRoleGR = new GlideRecord('sys_user_has_role');
+        newUserRoleGR.initialize();
+        newUserRoleGR.user = userGR.sys_id;
+        newUserRoleGR.role = roleGR.sys_id;
+        newUserRoleGR.insert();
+        count++;
+    }
+}
+
+gs.info('Assigned role "' + roleName + '" to ' + count + ' users.');


### PR DESCRIPTION
This is a script that assigns roles to users in bulk based on specific conditions such as department,location or job title. This script can simplify the process of managing user roles and permissions. Use Case: Assign the 'itil' role to all users in the 'IT' department who are located in a specific region.