### PR TITLE
Teams Integration Token Refresh

### DIFF
--- a/Fix scripts/Fix teams token/fix-teams-token.js
+++ b/Fix scripts/Fix teams token/fix-teams-token.js
@@ -1,0 +1,8 @@
+var userId = ''; // Place the userID of the user to whom you want to restart the teams token
+var azureGr = new GlideRecord("sn_now_azure_user");
+azureGr.addQuery('user.user_name',userId);
+azureGr.query();
+if(azureGr.next()){
+	// gs.print(azureGr.upn);	Check if the record is valid one or not
+    azureGr.deleteRecord();
+}

--- a/Fix scripts/Fix teams token/readme.md
+++ b/Fix scripts/Fix teams token/readme.md
@@ -1,0 +1,1 @@
+This script helps to fix the MS teams integration token for a specific user. Once the script has been executed, the user can try to reinitiate the teams from the task to retrieve a new token.


### PR DESCRIPTION
This script helps to fix the MS teams integration token for a specific user. Once the script has been executed, the user can try to reinitiate the teams from the task to retrieve a new token.