### PR TITLE
Create count fields in a table

### DIFF
--- a/Background Scripts/Bulk Update Tables/count fields in a table
+++ b/Background Scripts/Bulk Update Tables/count fields in a table
@@ -1,0 +1,9 @@
+var gr = new GlideRecord('sys_user');
+gr.query();
+
+var count = 0;
+while (gr.next()) {
+    count++;
+}
+
+gs.info("Count of fields in sys_user table: " + count);


### PR DESCRIPTION
This script will count the number of fields in the sys_user table and display the count in the console.

Here's a breakdown of what the script does:

Creates a new GlideRecord object for the sys_user table. Queries the table to retrieve all records.
Iterates through the records and increments the count variable for each record. Displays the final count value in the console.