### PR TITLE
Bookmarks

### DIFF
--- a/Background Scripts/Bookmarks/readme.md
+++ b/Background Scripts/Bookmarks/readme.md
@@ -1,0 +1,6 @@
+Script to add bookmarks
+- SLA for my Group Tasks
+- SLA for my Tasks
+- Task assigned to me
+- My approvals
+for ITIL users

--- a/Background Scripts/Bookmarks/script.js
+++ b/Background Scripts/Bookmarks/script.js
@@ -1,0 +1,25 @@
+var jsonFavList = {
+  "SLA for My Group Tasks": "task_list.do?sysparm_query=assignment_groupDYNAMICd6435e965f510100a9ad2572f2b47744&sysparm_first_row=1&sysparm_view=",
+  "SLA for My Tasks": "task_list.do?sysparm_query=%5Eassigned_toDYNAMIC90d1921e5f510100a9ad2572f2b477fe&sysparm_first_row=1&sysparm_view=",
+  "Tasks Assigned to Me": "stateNOT INclosed_complete,closed_abandoned^assigned_toDYNAMIC90d1921e5f510100a9ad2572f2b477fe",
+  "My approvals": "sysapproval_approver_list.do?sysparm_query=approverDYNAMIC90d1921e5f510100a9ad2572f2b477fe&sysparm_first_row=1&sysparm_view="
+};
+
+var g = new GlideRecord("sys_user_has_role");
+g.addEncodedQuery("role=282bf1fac6112285017366cb5f867469");//considering sys_id for ITIL role is 282bf1fac6112285017366cb5f867469
+g.query();
+while (g.next()) {
+	for (var fav in jsonFavList) {
+		var grBookMark = new GlideRecord("sys_ui_bookmark");
+		grBookMark.addEncodedQuery("user=" + g.user + "^title=" + fav + "^url=" + jsonFavList[fav]);
+		grBookMark.query();
+		if (!grBookMark.next()) {
+			grBookMark.initialize();
+			grBookMark.pinned = true;
+			grBookMark.title = fav;
+			grBookMark.url = jsonFavList[fav];
+			grBookMark.user = g.user;
+			grBookMark.insert();
+		}
+	}
+}

--- a/Server Side/Custom Relationship/readme.md
+++ b/Server Side/Custom Relationship/readme.md
@@ -1,0 +1,3 @@
+Instead of duplicating attachment by use of GlideSysAttachment.copy() simplest approach is to create a relationship from System Definition >> Relationship & then display it as a Related list on required set of Tables were attachments are to be shown.
+
+So, for a case where attachments from REQ (sc_request) are to be on RITM (sc_req_item) table then a relationship as below would suffice.

--- a/Server Side/Custom Relationship/script.js
+++ b/Server Side/Custom Relationship/script.js
@@ -1,0 +1,12 @@
+(function refineQuery(current, parent) {
+
+    var queryString = "table_nameINsc_request^table_sys_idIN" + parent.getValue("request");
+    var gr = new GlideRecord("sc_req_item");
+    gr.addQuery("request", parent.getValue("request"));
+    gr.query();
+    while (gr.next()) {
+        queryString += "," + gr.sys_id.toString();
+    }
+    current.addEncodedQuery(queryString);
+
+})(current, parent);


### PR DESCRIPTION
Instead of duplicating attachment by use of GlideSysAttachment.copy() simplest approach is to create a relationship from System Definition >> Relationship & then display it as a Related list on required set of Tables were attachments are to be shown.

So, for a case where attachments from REQ (sc_request) are to be on RITM (sc_req_item) table then a relationship as below would suffice.