### PR TITLE
Create millisecondsToDuration.js

### DIFF
--- a/millisecondsToDuration.js
+++ b/millisecondsToDuration.js
@@ -1,0 +1,9 @@
+(function execute(inputs, outputs) {
+
+var gdt0 = new GlideDateTime("1970-01-01 00:00:00"); //Epoch DateTime
+var gdt1 = inputs.milliseconds;
+gdt0.add(gdt1); // Adds the milliseconds to the epoch date/time
+
+outputs.time = gdt0.toString(); 
+
+})(inputs, outputs);


### PR DESCRIPTION
When calculating date/time fields they are usually converted into milliseconds using dateNumericValue(). To be able to write the result back in Flow Designer using the Update Record action into a Duration field, the calculated milliseconds need to be converted back. 

The script is taking the Epoch DateTime (1970-01-01 00:00:00) and adds the milliseconds back to it, so get the duration value. It then converts it into a string so it can be inserted back.

The input for the action will be the milliseconds from a flow calculation e.g. a flow variable and the output will be the time value as a duration