### PR TITLE
Sync Data Between Two ServiceNow Instances via REST API

### DIFF
--- a/Fix scripts/Sync Data Between Instances/SyncData.js
+++ b/Fix scripts/Sync Data Between Instances/SyncData.js
@@ -1,0 +1,35 @@
+//Add below Details
+var table = "sys_user";
+var query = "active=true";
+var targetInstance = "dev1234";
+var user, password;
+
+sendData(table, targetInstance, query, user, password);
+
+function sendData(table, targetInstance, query) {
+    var pload = {};
+    var tableGR = new GlideRecord(table);
+    if (query) {
+        tableGR.addQuery(query);
+    }
+    tableGR.query();
+    while (tableGR.next()) {
+        var dictionaryGR = new GlideRecord('sys_dictionary');
+        dictionaryGR.addQuery('name=' + table);
+        dictionaryGR.query();
+        while (dictionaryGR.next()) {
+            var element = dictionaryGR.element.toString();
+            pload[dictionaryGR.element] = tableGR.getValue(element);
+        }
+        var requestBody = JSON.stringify(pload);
+        //gs.info(requestBody);
+        var request = new sn_ws.RESTMessageV2();
+        request.setEndpoint('https://' + targetInstance + '.service-now.com/api/now/table/' + table);
+        request.setHttpMethod('POST');
+        request.setBasicAuth(user, password);
+        request.setRequestHeader("Accept", "application/json");
+        request.setRequestBody(requestBody);
+        var response = request.execute();
+        gs.log(response.getBody());
+    }
+}

--- a/Fix scripts/Sync Data Between Instances/readme.md
+++ b/Fix scripts/Sync Data Between Instances/readme.md
@@ -1,0 +1,16 @@
+The script leverages the ServiceNow REST API to retrieve records from a specified table on the source instance, then transmits them to the target instance for insertion.
+
+As an example, it is set up to sync active user records, but it can be easily modified for any other table and filter criteria.
+
+
+Usage:
+
+The script is configured with the following parameters:
+
+table: Specifies the name of the table to sync (Example is sys_user).
+
+query: A GlideRecord query string to filter the records to be synchronized
+
+targetInstance: The ServiceNow instance to which data will be sent.
+
+user and password: Credentials for authenticating with the target instance.


### PR DESCRIPTION
Added my contribution to Fix scripts/Sync Data Between Instances.

This script enables seamless data synchronization between two ServiceNow instances using the ServiceNow Table API. By providing basic configuration details—such as the instance name, table name, query, and basic authentication details—this script automates the transfer of data, ensuring consistency across environments.