### PR TITLE
Prevent duplicate update sets

### DIFF
--- a/Business Rules/Prevent duplicate update sets/preventDuplcateUpdateSets.js
+++ b/Business Rules/Prevent duplicate update sets/preventDuplcateUpdateSets.js
@@ -1,0 +1,14 @@
+(function executeRule(current, previous /*null when async*/) {
+    
+    var updateSetName = current.name.toString().trim();
+    var grUpdateSet = new GlideRecord('sys_update_set');
+    grUpdateSet.addQuery('name', updateSetName);
+    grUpdateSet.addQuery('sys_id', '!=', current.sys_id);
+    grUpdateSet.query();
+    
+    if (grUpdateSet.hasNext()) {
+        gs.addErrorMessage('An update set with this name already exists. Please choose a different name.');
+        current.setAbortAction(true);
+    }
+    
+})(current, previous);

--- a/Business Rules/Prevent duplicate update sets/readme.md
+++ b/Business Rules/Prevent duplicate update sets/readme.md
@@ -1,0 +1,1 @@
+This Business Rule will help to prevent duplicate names for update set. And this will display error message when there is duplicate name found for update set name.


### PR DESCRIPTION
Adding new Business Rule to Prevent duplicate names for update sets.

1.  this will validate if there is any update set exist with name of the current update set 
2. if there is any existing update srt with same name it will display error and abort the action.