### PR TITLE
Sync Assigned to on RITM for specific catalog item

### DIFF
--- a/Business Rules/RITM Assignment Sync/Populate_Assigned _To_on_RITMs_for_Specific_Catalog_Item.js
+++ b/Business Rules/RITM Assignment Sync/Populate_Assigned _To_on_RITMs_for_Specific_Catalog_Item.js
@@ -1,0 +1,12 @@
+// create business rule on sc_request table 
+(function executeRule(current, previous /*null when async*/ ) {
+
+    var grRITM = new GlideRecord('sc_req_item');
+    grRITM.addQuery('request', current.sys_id);
+    grRITM.addQuery("cat_item.sc_catalogs", "791b6df48798d9100072960d3fbb35be"); //sys_id of catalog 
+    grRITM.query();
+    while (grRITM.next()) {
+        grRITM.assigned_to = current.assigned_to;
+        grRITM.update();
+    }
+})(current, previous);

--- a/Business Rules/RITM Assignment Sync/readme.md
+++ b/Business Rules/RITM Assignment Sync/readme.md
@@ -1,4 +1,4 @@
-#Script Explanation:
+# Script Explanation:
 This script is written for a Business Rule in ServiceNow. The purpose of this rule is to assign the same assigned_to value (typically a user) from the request to all related requested items (RITMs)
 in the same catalog for a specific catalog item.
 This script could be used in scenarios where, once a request is assigned to a particular user (or group), you want all the individual requested items (RITMs) tied to that request to also automatically be assigned to the same user. 

--- a/Business Rules/RITM Assignment Sync/readme.md
+++ b/Business Rules/RITM Assignment Sync/readme.md
@@ -1,0 +1,5 @@
+Script Explanation:
+This script is written for a Business Rule in ServiceNow. The purpose of this rule is to assign the same assigned_to value (typically a user) from the request to all related requested items (RITMs)
+in the same catalog for a specific catalog item.
+This script could be used in scenarios where, once a request is assigned to a particular user (or group), you want all the individual requested items (RITMs) tied to that request to also automatically be assigned to the same user. 
+This ensures consistency in assignment across the items in a request.

--- a/Business Rules/RITM Assignment Sync/readme.md
+++ b/Business Rules/RITM Assignment Sync/readme.md
@@ -1,4 +1,4 @@
-Script Explanation:
+#Script Explanation:
 This script is written for a Business Rule in ServiceNow. The purpose of this rule is to assign the same assigned_to value (typically a user) from the request to all related requested items (RITMs)
 in the same catalog for a specific catalog item.
 This script could be used in scenarios where, once a request is assigned to a particular user (or group), you want all the individual requested items (RITMs) tied to that request to also automatically be assigned to the same user. 


### PR DESCRIPTION
The script takes the assigned_to field from the current request record and assigns it to all related RITM records that belong to a specific catalog item