### PR TITLE
Encrypt and Decrypt Non-password fields

### DIFF
--- a/Background Scripts/encryptAndDecryptPasswordFields.js
+++ b/Background Scripts/encryptAndDecryptPasswordFields.js
@@ -1,0 +1,15 @@
+//For Non-password fields Encryption syntax using Key Management Framework Cryptographic module
+
+var password = "Hello World";
+var encryptOp = new sn_kmf_ns.KMFCryptoOperation("global.vamsi_glideencrypter", "SYMMETRIC_ENCRYPTION")
+ .withInputFormat("KMFNone");
+var encryptedText = encryptOp.doOperation(password); //Encrypting Hello world
+gs.info("After Encryption: " + encryptedText);
+
+
+//For Non-password fields Decryption syntax using Key Management Framework Cryptographic module
+
+var encryptOp = new sn_kmf_ns.KMFCryptoOperation("global.vamsi_glideencrypter", "SYMMETRIC_DECRYPTION")
+ .withOutputFormat("KMFNone");
+var clear_text = encryptOp.doOperation('91ddbb5d47c012101b589d2f316d438012p3lgrR72vEQW5yLk-WXKQ==aGqxYzUXuyLt3HTqcW6-HA=='); //Pass Cipher text of Hello World (Which is the output of first script)
+gs.info("After decryption: " + clear_text);

--- a/Background Scripts/readme.md
+++ b/Background Scripts/readme.md
@@ -1,0 +1,11 @@
+Generally when you want to encrypt or decrypt any Non-password fields earlier we have Glide Encrypter API methods for encryption and decryption. 
+The GlideEncrypter API uses 3DES encryption standard with NIST 800-131 A Rev2 has recommended against using to encrypt data after 2023. 
+ServiceNow offers alternative cryptographic (Key Management Framwork) solutions to the GlideEncrypter API. 
+
+Note: ServiceNow recommending to deprecate GlideEncrypter API with in the instances as soon as possible. The actual dead line is September 2025.
+
+These are the sample scripts I ran in my PDI: For Non-password fields. I used AES 256 algorithm for Symmetric Data Encryption/Decryption.
+
+To test the scripts you need to create Cryptographic module and generate the key. 
+
+"global.vamsi_glideencrypter" is my cryptographic module name.


### PR DESCRIPTION
Generally when you want to encrypt or decrypt any Non-password fields earlier we have Glide Encrypter API methods for encryption and decryption. 
The GlideEncrypter API uses 3DES encryption standard with NIST 800-131 A Rev2 has recommended against using to encrypt data after 2023. 
ServiceNow offers alternative cryptographic (Key Management Framwork) solutions to the GlideEncrypter API. 

Note: ServiceNow recommending to deprecate GlideEncrypter API with in the instances as soon as possible. The actual dead line is September 2025.

These are the sample scripts I ran in my PDI: For Non-password fields. I used AES 256 algorithm for Symmetric Data Encryption/Decryption.

To test the scripts you need to create Cryptographic module and generate the key. 

"global.vamsi_glideencrypter" is my cryptographic module name.