### PR TITLE
Fix script to Update/add write roles to variables (catalog item variables)

### DIFF
--- a/Fix scripts/update variable role/README.md
+++ b/Fix scripts/update variable role/README.md
@@ -1,0 +1,19 @@
+# Fix script to update varialbes write roles
+
+- we use variables in catalog items for that we have to provide roles who can access the variable
+- we tend to forget adding roles after creating many varialbes
+- To update multiple variables write role this fix script will help to add them.
+
+
+```
+function updateItemOptionRoles() {
+     var query = 'sys_scope=5f414691db10a4101b2733f3b9961961';   // sys_id of application
+     var varGr = new GlideRecord('item_option_new');  // GlideRecord of variables table
+     varGr.addEncodedQuery(query);
+     varGr.query();
+     gs.info('Starting update for ' + varGr.getRowCount() + ' records.'); 
+     varGr.setValue('write_roles', 'role1, role2, role3'); // add the write roles 
+     varGr.updateMultiple();
+    gs.info('Updated ' + varGr.getRowCount() + ' records.');
+ }
+```

--- a/Fix scripts/update variable role/updateWriteRolesOfVariables.js
+++ b/Fix scripts/update variable role/updateWriteRolesOfVariables.js
@@ -1,0 +1,16 @@
+// Fix script to update varialbes write roles 
+function updateItemOptionRoles() {
+    var query = 'sys_scope=5f414691db10a4101b2733f3b9961961'; // sys_id of application
+    var varGr = new GlideRecord('item_option_new');
+    varGr.addEncodedQuery(query);
+    varGr.query();
+
+    gs.info('Starting update for ' + varGr.getRowCount() + ' records.');
+
+    varGr.setValue('write_roles', 'role1, role2, role3'); // 
+    varGr.updateMultiple();
+
+    gs.info('Updated ' + varGr.getRowCount() + ' records.');
+}
+
+updateItemOptionRoles();


### PR DESCRIPTION
Fix script to update the write role in variables (item_option_new) table. In catalog item we find variables, to give write access to multiple variable we use fix script to add write roles in variables bulk update. By adding write roles we achieve who can have the edit access on catalog form for the particular variables. 