### PR TITLE
Reminder Emails One Day Before Downtime

### DIFF
--- a/Scheduled Jobs/Reminder Emails One Day Before Downtime/Script.js
+++ b/Scheduled Jobs/Reminder Emails One Day Before Downtime/Script.js
@@ -1,0 +1,19 @@
+// Scheduled Script Execution for Reminder
+(function() {
+    var changeRequests = new GlideRecord('change_request');
+    changeRequests.addQuery('start_date', '=', GlideDateTime.now().getGlideObject().addDays(1)); // 1 day before
+    changeRequests.query();
+
+    while (changeRequests.next()) {
+        var email = new GlideEmailOutbound();
+        email.setSubject('Reminder: Upcoming Scheduled Downtime');
+        email.setTo('globalplatform@universal.com'); // Replace with your distribution list
+        email.setBody('Reminder:\n\n' +
+                      'Scheduled downtime will occur tomorrow on ' + changeRequests.start_date + ' for maintenance.\n' +
+                      'Expected duration: ' + changeRequests.duration + ' hours.\n' +
+                      'Impact: ' + changeRequests.impact + '\n\n' +
+                      'Please plan accordingly.\n\n' +
+                      'Thank you for your understanding.');
+        email.send();
+    }
+})();

--- a/Scheduled Jobs/Reminder Emails One Day Before Downtime/readme.md
+++ b/Scheduled Jobs/Reminder Emails One Day Before Downtime/readme.md
@@ -1,0 +1,15 @@
+Reminder Emails One Day Before Downtime
+
+This script is designed to send reminder emails to users one day before scheduled downtime, ensuring they are aware of upcoming maintenance events. 
+In a fast-paced work environment, where IT systems are crucial, unexpected downtime can disrupt workflows and impact productivity. By providing timely notifications, 
+the script allows users to prepare for interruptions, adjust their schedules, and minimize negative impacts on their tasks. 
+These reminders foster transparency and collaboration between IT and end users, mitigating confusion and building trust within the organization. 
+Ultimately, users feel informed and empowered to manage their work around planned downtimes.
+
+Key Features
+- Proactive Notifications : Sends reminder emails 24 hours before downtime to prepare users.
+- Dynamic Querying : Uses the change_request table to find relevant downtime events.
+- Customizable Recipient List : Targets specific user groups for tailored communication.
+- Detailed Email Content : Includes key details like scheduled date, duration, and impact.
+- Easy Integration : Automatically scheduled within ServiceNow for consistent reminders.
+- Improved User Awareness : Increases transparency about IT operations, keeping users informed.


### PR DESCRIPTION
This script is designed to send reminder emails to users one day before scheduled downtime, ensuring they are aware of upcoming maintenance events. 
In a fast-paced work environment, where IT systems are crucial, unexpected downtime can disrupt workflows and impact productivity. By providing timely notifications, 
the script allows users to prepare for interruptions, adjust their schedules, and minimize negative impacts on their tasks. 
These reminders foster transparency and collaboration between IT and end users, mitigating confusion and building trust within the organization. 
Ultimately, users feel informed and empowered to manage their work around planned downtimes.
