### PR TITLE
TechTrekwithAJ-cmdb mandatory field analysis for computer class

### DIFF
--- a/CMDB/Mandatory Field Analysis/TechTrekwithAJ-CMDBMandatoryfieldanalysis.js
+++ b/CMDB/Mandatory Field Analysis/TechTrekwithAJ-CMDBMandatoryfieldanalysis.js
@@ -1,0 +1,31 @@
+(function() {
+    // Define the CMDB table you want to analyze
+    var cmdbTableName = 'cmdb_ci_computer'; // Replace with your desired CMDB class name
+    var mandatoryFields = ['name', 'sys_class_name', 'location', 'install_status']; // Replace with your mandatory fields
+    var missingFieldsCount = 0;
+
+    // GlideRecord to query the specified CMDB table
+    var gr = new GlideRecord(cmdbTableName);
+    gr.query();
+
+    // Iterate through all records in the specified CMDB table
+    while (gr.next()) {
+        var missingFields = [];
+
+        // Check each mandatory field for a value
+        mandatoryFields.forEach(function(field) {
+            if (!gr.getValue(field)) {
+                missingFields.push(field);
+            }
+        });
+
+        // Log the record if any mandatory fields are missing
+        if (missingFields.length > 0) {
+            gs.info('Record missing mandatory fields: ' + gr.sys_id + ' (' + gr.name + '). Missing fields: ' + missingFields.join(', '));
+            missingFieldsCount++;
+        }
+    }
+
+    // Log the total number of records missing mandatory fields
+    gs.info('Total records missing mandatory fields: ' + missingFieldsCount);
+})();

--- a/CMDB/Mandatory Field Analysis/TechTrekwithAJ-cmdbmandatoryfielddescription_readme.md
+++ b/CMDB/Mandatory Field Analysis/TechTrekwithAJ-cmdbmandatoryfielddescription_readme.md
@@ -1,0 +1,13 @@
+ CMDB Table Definition:
+        cmdbTableName specifies the CMDB class you want to analyze (e.g., cmdb_ci_computer).
+        Modify this to the desired table name.
+Mandatory Fields Array:
+        mandatoryFields is an array that holds the names of the fields you want to check for mandatory values. Customize this list as per your requirements.
+GlideRecord Query:
+        A GlideRecord object is created to query the specified CMDB table.
+Iteration and Check:
+        The script iterates through all records in the CMDB table and checks each mandatory field to see if it is populated.
+        If a mandatory field is missing, it adds the field name to the missingFields array.
+Logging:
+        If any mandatory fields are missing for a record, it logs the record's sys_id and name, along with the missing fields.
+        It also counts and logs the total number of records with missing mandatory fields at the end.


### PR DESCRIPTION
To perform a CMDB (Configuration Management Database) Mandatory Field Analysis in ServiceNow,that script that checks if mandatory fields are populated for a specific CMDB class. This script will typically run in a background script or a scheduled job.