### PR TITLE
Retrieve Connection and Credentials Information using Connection Alias (sys_id) in a Scoped Application

### DIFF
--- a/Script Includes/ConnectionCredentialsUtils/ConnectionCredentialUtils.js
+++ b/Script Includes/ConnectionCredentialsUtils/ConnectionCredentialUtils.js
@@ -1,0 +1,13 @@
+//A script include to retrieve Connection and Credentials Information using Connection Alias (sys_id) in a Scoped Application
+(function () {
+
+    var provider = new sn_cc.ConnectionInfoProvider();
+    var connectionInfo = provider.getConnectionInfo("<sys_id of sys_alias record");
+    if (!gs.nil(connectionInfo)) {
+        // get Connection Record Information (for ex: connection_url)
+        gs.info("Connection URL: " + connectionInfo.getAttribute("connection_url")); // to get other information, replace the connection_url with other field_name available in connection table.
+
+        // get Credential Record Information (for ex: password)
+        gs.info("Password: "+ connectionInfo.getCredentialAttribute("passowrd")); // to get other information, replace password with other field_name available in credenitals table.
+    }
+})();

--- a/Script Includes/ConnectionCredentialsUtils/readme.md
+++ b/Script Includes/ConnectionCredentialsUtils/readme.md
@@ -1,0 +1,11 @@
+# Retrieve Connection and Credentials Information using Connection Alias (sys_id) in a Scoped Application
+I've created a Script Include that enables users to retrieve connection and credentials details associated with a Scoped Application.
+
+In addition to providing this information, the Script Include also decrypts and returns the value of the password2 field. It supports a wide range of credential types, including:
+
+Basic Authentication credentials
+API Key credentials
+Windows credentials
+SSH credentials, and more.
+
+This tool simplifies access to important connection and credential data for all supported types in the scoped environment.


### PR DESCRIPTION
I've created a Script Include that enables users to retrieve connection and credentials details associated with a Scoped Application.

In addition to providing this information, the Script Include also decrypts and returns the value of the password2 field. It supports a wide range of credential types, including:

Basic Authentication credentials
API Key credentials
Windows credentials
SSH credentials, and more.
