### PR TITLE
The getIP4OrIPV6addressfunction extracts and returns all IPv4 and IPv6 addresses from a given text.

### DIFF
--- a/Regular Expressions/IP Address Validation/getIP4OrIPV6address.js
+++ b/Regular Expressions/IP Address Validation/getIP4OrIPV6address.js
@@ -1,0 +1,5 @@
+extractIPAddresses: function(text) {
+        var ipRegex = /\b((\d{1,3}\.){3}\d{1,3})\b|\b([a-fA-F0-9:]+:+[a-fA-F0-9:]+)\b/g;
+		var matches = text.match(ipRegex);
+        return matches;
+    },


### PR DESCRIPTION
The getIP4OrIPV6address.jsfunction extracts both IPv4 and IPv6 addresses from a given text. It uses a regular expression (ipRegex) to match patterns resembling IPv4 (four octets separated by dots) or IPv6 (hexadecimal digits separated by colons) addresses. The text.match(ipRegex) function searches the input text for all matching IP addresses and returns them as an array. If no matches are found, the result will be null. This regex covers the following:

Full IPv6 addresses (e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334).
Shorthand versions (e.g., fe80::1, where :: represents omitted zeros).
IPv6 with embedded IPv4 addresses (e.g., ::ffff:192.168.1.1).