### PR TITLE
Get CI Relationships associated with specific CMDB CI record.

### DIFF
--- a/CMDB/CMDB Get CI Relationships/README.md
+++ b/CMDB/CMDB Get CI Relationships/README.md
@@ -1,0 +1,2 @@
+# Retrieve CI Relationships present for particular CMDB CI record 
+This functionality allows users to obtain all configuration item (CI) relationships associated with a specific CMDB CI record. It provides detailed insights into how the selected CI is related to other CIs within the CMDB, enabling better management and understanding of infrastructure dependencies.

--- a/CMDB/CMDB Get CI Relationships/getCIRelationships.js
+++ b/CMDB/CMDB Get CI Relationships/getCIRelationships.js
@@ -1,0 +1,17 @@
+var cmdb_class_name = "<cmdb_ci_class_name>"; // Replace with your cmdb_table_name
+var record_sys_id = "<cmdb_ci_record_sys_id>"; // Replace with your cmdb_ci record sys_id
+
+var request = new sn_ws.RESTMessageV2();
+request.setHttpMethod('get');
+request.setEndpoint('https://<instance_name>.service-now.com/api/now/cmdb/instance/' + cmdb_class_name + "/" + record_sys_id);
+request.setBasicAuth('<instance_username>', '<instance_password>'); // Replace with your instance username and password
+var response = request.executeAsync();
+response.waitForResponse(60);
+
+if (response.getStatusCode() == 200) {
+    var body = JSON.parse(response.getBody());
+    gs.info("Inbbound Relationships: " + JSON.stringify(body.result.inbound_relations));
+    gs.info("Outbound Relationships: " + JSON.stringify(body.result.outbound_relations));
+} else {
+    gs.error("Error in API Response with statusCode: "+ response.getStatusCode())
+}


### PR DESCRIPTION
This functionality allows users to obtain all configuration item (CI) relationships associated with a specific CMDB CI record. It provides detailed insights into how the selected CI is related to other CIs within the CMDB.