### PR TITLE
Add ISBN validator regex and utility function

### DIFF
--- a/Regular Expressions/ISBN Validator/README.md
+++ b/Regular Expressions/ISBN Validator/README.md
@@ -1,0 +1,24 @@
+# ISBN Validator Regular Expression
+
+This JavaScript module provides a regular expression for validating International Standard Book Numbers (ISBNs). It supports both ISBN-10 and ISBN-13 formats, including variations with or without hyphens and spaces.
+
+## Features
+
+- Validates ISBN-10 and ISBN-13 formats
+- Supports ISBNs with or without hyphens/spaces
+- Accepts ISBNs with or without the "ISBN" prefix
+
+## Usage
+
+```javascript
+const isbnRegex = /^(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$/;
+
+function validateISBN(isbn) {
+  return isbnRegex.test(isbn);
+}
+
+// Example usage:
+console.log(validateISBN('ISBN 978-0-596-52068-7')); // true
+console.log(validateISBN('0-596-52068-9')); // true
+console.log(validateISBN('0 512 52068 9')); // false
+```

--- a/Regular Expressions/ISBN Validator/validateISBN.js
+++ b/Regular Expressions/ISBN Validator/validateISBN.js
@@ -1,0 +1,13 @@
+// ISBN Validator
+// This regex validates both ISBN-10 and ISBN-13 formats
+
+const isbnRegex = /^(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$/;
+
+function validateISBN(isbn) {
+  return isbnRegex.test(isbn);
+}
+
+// Example usage:
+console.log(validateISBN('ISBN 978-0-596-52068-7')); // true
+console.log(validateISBN('0-596-52068-9')); // true
+console.log(validateISBN('0 512 52068 9')); // false


### PR DESCRIPTION
This PR adds a new regular expression and utility function for validating International Standard Book Numbers (ISBNs). The implementation supports both ISBN-10 and ISBN-13 formats, with or without hyphens/spaces and the "ISBN" prefix.

Key changes:
- Add `isbnRegex` for matching valid ISBN formats
- Implement `validateISBN()` function for easy usage
- Include example usage in the code
- Add comprehensive README with usage instructions

This feature will be useful for e-commerce platforms, library systems, and any applications dealing with book-related data.