### PR TITLE
emailFormatValidator can be used while importing data and conform to a standard email format.

### DIFF
--- a/Transform Map Scripts/Email Formatter/emailFormatterValidator
+++ b/Transform Map Scripts/Email Formatter/emailFormatterValidator
@@ -1,0 +1,15 @@
+(function checkEmail(source, target, map, log, isUpdate) {
+// Replace with your source email field
+    var email = source.u_email; 
+    if (email) {
+        email = email.trim().toLowerCase();
+        //Regular Expression to validate email pattern
+        var emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (emailPattern.test(email)) {
+        // Replace with your target email field
+            target.email = email; 
+        } else {
+            log.info('Invalid email format for ' + email);
+        }
+    }
+})(source, target, map, log, isUpdate);

--- a/Transform Map Scripts/Email Formatter/readme.md
+++ b/Transform Map Scripts/Email Formatter/readme.md
@@ -1,0 +1,1 @@
+The purpose of this script is to validate email addresses during a data import in ServiceNow. It ensures that the email addresses conform to a standard format (i.e., are valid email addresses), converts them to lowercase, trims any extra spaces, and logs invalid email addresses for review or further action.


### PR DESCRIPTION
The purpose of this script is to validate email addresses during a data import in ServiceNow. It ensures that the email addresses conform to a standard format (i.e., are valid email addresses), converts them to lowercase, trims any extra spaces, and logs invalid email addresses for review or further action.