### PR TITLE
Field Place holder 

### DIFF
--- a/Catalog Client Script/PAN Validation /PAN Validation.js
+++ b/Catalog Client Script/PAN Validation /PAN Validation.js
@@ -1,0 +1,13 @@
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+    if (isLoading || newValue === '') {
+        return;
+    }
+    var panNumber = g_form.getValue("u_pan_number"); //Get the PAN card information
+    var panRegex = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/; // Regex for the PAN Card
+
+    if (panRegex.test(panNumber)) {
+        g_form.showFieldMsg("u_pan_number", "Valid PAN card number.", true); //Valid PAN card enterd populates this message 
+    } else {
+        g_form.showErrorBox("u_pan_number", "InValid PAN card number.", true); //In Valid PAN card details enterd populate this message 
+    }
+}

--- a/Catalog Client Script/PAN Validation /readme.md
+++ b/Catalog Client Script/PAN Validation /readme.md
@@ -1,0 +1,30 @@
+PAN is a ten-digit unique alphanumeric number issued by the Income Tax Department. 
+
+Indian PAN (Permanent Account Number) card based on its standardized format. 
+A PAN number is a unique 10-character alphanumeric identifier issued by the Indian government, and it follows a specific structure:
+
+First 5 characters: Uppercase English letters (A-Z).
+Next 4 characters: Numeric digits (0-9).
+Last character: A single uppercase English letter (A-Z).
+
+![image](https://github.com/user-attachments/assets/4e28deaf-e4df-4a0c-892e-d5025ad1a74c)
+
+When we provide the information in the mentioned format it validates as a valid PAN Card
+
+Eg: ABCDE1234F
+Result
+<img width="620" alt="image" src="https://github.com/user-attachments/assets/73ad9708-d413-4c6e-9222-c48c8b5d4d5f">
+
+Mentioned formate was not used it will give an error message to the field 
+Eg:abcde1234f
+<img width="618" alt="image" src="https://github.com/user-attachments/assets/cfcd5a3b-ac48-427f-98f3-9b1aa7eb4d53">
+
+Eg: 1234ABCDEF
+<img width="640" alt="image" src="https://github.com/user-attachments/assets/5648b7bd-670a-4c47-9335-b593d628e0a3">
+
+
+
+
+
+
+

--- a/Client Scripts/Field Placeholder/fieldplaceholder.js
+++ b/Client Scripts/Field Placeholder/fieldplaceholder.js
@@ -1,0 +1,5 @@
+function onLoad() {
+   //Type appropriate comment here, and begin script below
+   var shortDescription = g_form.getControl("short_description");
+   shortDescription.placeholder = "Please give the issue details here";
+}

--- a/Client Scripts/Field Placeholder/readme.md
+++ b/Client Scripts/Field Placeholder/readme.md
@@ -1,0 +1,7 @@
+Hint that appears inside an input field to indicate the type of data the user should enter. 
+It is typically shown in a lighter font color and disappears once the user starts typing.
+This helps guide users by providing an example or context without taking up additional space on the form.
+
+For example, a field placeholder in an short description input might read: "Please give the issue details here"
+
+<img width="661" alt="image" src="https://github.com/user-attachments/assets/9f0a8838-67e0-4d66-817c-6be292d585cc">


### PR DESCRIPTION
Hint that appears inside an input field to indicate the type of data the user should enter. It is typically shown in a lighter font color and disappears once the user starts typing. This helps guide users by providing an example or context without taking up additional space on the form.

For example, a field placeholder in an short description input might read: "Please give the issue details here"

<img width="661" alt="image" src="https://github.com/user-attachments/assets/749b57d0-3414-413f-90f1-3af3910f11a6">
