### PR TITLE
Field Placeholder 

### DIFF
--- a/Client Scripts/Field Placeholder/fieldplaceholder.js
+++ b/Client Scripts/Field Placeholder/fieldplaceholder.js
@@ -1,0 +1,5 @@
+function onLoad() {
+   //Type appropriate comment here, and begin script below
+   var shortDescription = g_form.getControl("short_description");
+   shortDescription.placeholder = "Please give the issue details here";
+}

--- a/Client Scripts/Field Placeholder/readme.md
+++ b/Client Scripts/Field Placeholder/readme.md
@@ -1,0 +1,6 @@
+Hint that appears inside an input field to indicate the type of data the user should enter. 
+It is typically shown in a lighter font colour and disappears once the user starts typing. 
+This helps guide users by providing an example or context without taking up additional space on the form.
+For example, a field placeholder in an short description input might read: "Please give the issue details here"
+ 
+![image](https://github.com/user-attachments/assets/600d8ba7-2322-4b7f-b769-41f464082341)


### PR DESCRIPTION
Hint that appears inside an input field to indicate the type of data the user should enter. It is typically shown in a lighter font colour and disappears once the user starts typing. This helps guide users by providing an example or context without taking up additional space on the form.
For example, a field placeholder in an short description input might read: "Please give the issue details here"
![image](https://github.com/user-attachments/assets/a55562b6-4876-4b7c-a4d3-186365079127)
