### PR TITLE
Add Hexadecimal Color Code Validator

### DIFF
--- a/Regular Expressions/Hexadecimal Color Code Validator/README.md
+++ b/Regular Expressions/Hexadecimal Color Code Validator/README.md
@@ -1,0 +1,39 @@
+# Hexadecimal Color Code Validator
+
+This JavaScript module provides a regular expression for validating hexadecimal color codes, commonly used in web development (CSS, HTML, etc.).
+
+## Features:
+
+- Validates 3-digit or 6-digit hexadecimal color codes.
+- Supports uppercase or lowercase letters.
+- Accepts color codes both with and without the leading `#` symbol.
+- Ensures that only valid hexadecimal characters (0-9, a-f, A-F) are used.
+
+### **Examples of Valid Hex Codes:**
+
+- `#ff5733` (6 digits, lowercase)
+- `#FFF` (3 digits, uppercase)
+- `fff` (3 digits, lowercase, without `#`)
+- `FF5733` (6 digits, uppercase, without `#`)
+
+### **Examples of Invalid Hex Codes:**
+
+- `#123abz` (contains invalid character `z`)
+- `#1234` (invalid length)
+- `#ZZZ999` (invalid characters)
+- `1234567` (invalid length)
+
+## Usage:
+
+```javascript
+const hexColorRegex = /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/;
+
+function validateHexColor(color) {
+  return hexColorRegex.test(color);
+}
+
+// Example usage:
+console.log(validateHexColor("#ff5733")); // true
+console.log(validateHexColor("fff")); // true
+console.log(validateHexColor("#123abz")); // false
+```

--- a/Regular Expressions/Hexadecimal Color Code Validator/validateHexColor.js
+++ b/Regular Expressions/Hexadecimal Color Code Validator/validateHexColor.js
@@ -1,0 +1,17 @@
+// Hexadecimal Color Code Validator
+// This regex validates 3 or 6 digit hexadecimal color codes (with or without #).
+// It handles both uppercase and lowercase hex characters.
+
+const hexColorRegex = /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/;
+
+function validateHexColor(color) {
+  return hexColorRegex.test(color);
+}
+
+// Example usage:
+console.log(validateHexColor("#ff5733")); // true - valid 6-digit color
+console.log(validateHexColor("fff")); // true - valid 3-digit color without #
+console.log(validateHexColor("#FFF")); // true - valid 3-digit uppercase
+console.log(validateHexColor("ff5733")); // true - valid 6-digit color without #
+console.log(validateHexColor("#123abz")); // false - invalid hex color (z is not valid)
+console.log(validateHexColor("#1234")); // false - invalid length


### PR DESCRIPTION
Introduces an enhanced regular expression and utility function for validating hexadecimal color codes in both 3-digit and 6-digit formats. The implementation improves upon standard validation by handling edge cases and ensuring support for both uppercase and lowercase hexadecimal characters, with or without the leading `#` symbol.

### Key Changes:
- Added `hexColorRegex` to validate 3-digit and 6-digit hex color codes, supporting optional `#`.
- Implemented `validateHexColor()` function to check if a string is a valid hex color.
- Updated README with detailed usage examples, feature descriptions, and valid/invalid test cases.

### Features:
- **Supports Uppercase and Lowercase Hex Values**: Handles both uppercase (`#FFF`) and lowercase (`#fff`) color codes.
- **Optional Leading `#`**: Accepts color codes with or without the leading `#`.
- **Validates 3 and 6-Digit Hex Codes**: Allows for shorthand hex color codes (3-digits) as well as full 6-digit codes.
