### PR TITLE
Change Request risk Assesment mandatory when moving from new state

### DIFF
--- a/Business Rules/Change Risk Assesment mandatory before state change/readme.md
+++ b/Business Rules/Change Risk Assesment mandatory before state change/readme.md
@@ -1,0 +1,3 @@
+This is a code snippet which can be used in a Business rule to prevent the state of Change Request Move from New state when there is no risk Assesment attached to the Change Request.
+Table : change_request When: Before Update: True Conditions : state || CHANGESFROM || New AND state || is not || Cancelled AND type || is one of || Normal,Emergency
+Note: This script is helpful for all the tables and their related tables which has assesmenets enabled, The BR should be created on related table and filters can be added accordingly

--- a/Business Rules/Change Risk Assesment mandatory before state change/script.js
+++ b/Business Rules/Change Risk Assesment mandatory before state change/script.js
@@ -1,0 +1,14 @@
+(function executeRule(current, previous /*null when async*/ ) {
+
+   //  Assesments once submitted are stored in Assesment Instances Table with record value mapped.
+    var assessmentinstance = new GlideRecord('asmt_assessment_instance');
+    assessmentinstance.addQuery('task_id', current.sys_id); //
+    assessmentinstance.setLimit(1);
+    assessmentinstance.query();// Query the record
+    if (!assessmentinstance.hasNext()) //If there are no assesments 
+    {
+        gs.addInfoMessage('Please perform risk assesment before requesting for approval');
+        current.setAbortAction(true);
+        action.setRedirectURL(current);
+    }
+})(current, previous);


### PR DESCRIPTION
This is a code snippet which can be used in a Business rule to prevent the state of Change Request Move from New state when there is no risk Assesment attached to the Change Request.
Table : change_request When: Before Update: True Conditions : state || CHANGESFROM || New AND state || is not || Cancelled AND type || is one of || Normal,Emergency
Note: This script is helpful for all the tables and their related tables which has assesmenets enabled, The BR should be created on related table and filters can be added accordingly
