### PR TITLE
UX Data broker to fetch system property in UI Builder

### DIFF
--- a/UX Data Broker Transform/FetchSysProperty/readme.md
+++ b/UX Data Broker Transform/FetchSysProperty/readme.md
@@ -1,0 +1,10 @@
+Once this code snippet is added in a new transform data broker in sys_ux_data_broker_transform table, this will start showing up in UIB data resources. 
+Once the data resource is added to the page of any experience, the user only needs to input the property_name field and rest will be take care of. 
+Just a note that in the data broker record properties field, please add below json object:
+[ { "name": "property_name", 
+"label": "Property", 
+"fieldType": "string",
+"readOnly": false, 
+"mandatory": true, 
+"defaultValue": "", 
+"description": "System property name" } ]

--- a/UX Data Broker Transform/FetchSysProperty/sysPropdataBroker.js
+++ b/UX Data Broker Transform/FetchSysProperty/sysPropdataBroker.js
@@ -1,0 +1,21 @@
+//Once this is saved, it will show up in UI Builder as a Data Resource which can be selected if the user wants to fetch system property table values.
+function transform(input){
+//property_name is one of the properties that the UX Transform Data broker needs. It's a field name.
+var property_name = input.property_name;
+var objProp = {};
+if(!property_name){
+objProp.errorValue = 'Please provide the property name.';
+return objProp;
+}
+var grSysProp = new GlideRecord('sys_properties');
+grSysProp.addQuery('name',input.property_name);
+grSysProp.query();
+if(grSysProp.next()){
+objProp.value = grSysProp.getValue('value');
+}
+if(!objProp.hasOwnProperty('value')){
+objProp.noPropertyFound = `The property ${property_name} was not found.`;
+return objProp;
+}
+return objProp;
+}


### PR DESCRIPTION
This script can be used in UX Data Broker transform script which once saved will be shown as a data resource in UIB experience page. Once it's added to the page, the user can simply provide the property name to fetch the property value from sys_properties table in the platform. which can be subsequently used in state parameters or in any component.