### PR TITLE
Get Duplicates

### DIFF
--- a/Background Scripts/Get Duplicate/readme.md
+++ b/Background Scripts/Get Duplicate/readme.md
@@ -1,0 +1,3 @@
+Using GlideAggregate function to find out tickets (tasks) with same number. OOB there happens to be a Unique checkbox at dictionary level
+and if in case not set to True it might create duplicate numbered tickets.
+Script will help find, ticekts if any.

--- a/Background Scripts/Get Duplicate/script.js
+++ b/Background Scripts/Get Duplicate/script.js
@@ -1,0 +1,8 @@
+var dpchk = new GlideAggregate('task');               
+dpchk.groupBy('number');                             
+dpchk.addHaving('COUNT', '>', 1);
+dpchk.query();
+while(dpchk.next())	
+{
+		gs.print(dpchk.number);                               
+}


### PR DESCRIPTION
Using GlideAggregate function to find out tickets (tasks) with same number. OOB there happens to be a Unique checkbox at dictionary level and if in case not set to True it might create duplicate numbered tickets.
Script will help find, tickets if any.