### PR TITLE
Add Utility Function to Retrieve Field Names from GlideRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,23 @@
-![Code Snippets Banner](https://github.com/ServiceNowDevProgram/code-snippets/assets/31702109/f9fa072a-4c0c-426b-8eed-200c6616ff60)
+# GlideRecord Field Names Utility
 
-Welcome to ServiceNow's Code Snippets community repository, managed by the Developer Program and the sndevs Slack community.
+## Overview
+The **GlideRecord Field Names Utility** is a JavaScript function designed for ServiceNow developers. This utility retrieves the names of all fields present in a given GlideRecord instance. It simplifies the process of dynamically accessing field names, which can be particularly useful in scenarios involving data manipulation or logging.
 
-Inside this repository, you will find community submitted code-snippets and their variants for different use-cases.
+## Features
+- Safely checks if the provided GlideRecord instance is valid and not empty.
+- Returns an array of field names for the given GlideRecord.
+- Avoids errors by handling invalid input gracefully.
 
-**Note:** ServiceNowDevProgram has many repositories that can be imported directly into ServiceNow, this is not one of them; This repository is meant to be edited directly in GitHub or any other Git-enabled IDE like VS Code.
+## Installation
+To use the `getFieldNames` function in your ServiceNow scripts, simply copy the function into your script or business rule where you need to retrieve field names.
 
-## Disclaimer
+## Usage
+Here’s how you can use the `getFieldNames` function:
 
-Please note the following:
-
-1. **Community-Sourced Code**: The code found in this repository is contributed by members of the community and has not been vetted or officially endorsed by the repository owners.
-
-2. **Use at Your Own Risk**: Users are advised to exercise caution and thoroughly review the code before implementing it in their ServiceNow instances. We strongly recommend a comprehensive review to ensure the code aligns with your specific requirements and security standards.
-
-3. **Reporting Mistakes and Issues**: If you come across any mistakes, issues, or improvements in the code, we encourage you to report them and consider contributing to the repository by submitting corrections or enhancements.
-
-4. **No Warranty or Support**: This repository is provided as-is, without any warranties or guarantees. It does not come with official support from the ServiceNow team or the repository owners.
-
-By using the code from this repository, you acknowledge that you have read and understood this disclaimer. Your use of the code is at your own discretion and risk.
-
-We appreciate your participation and contributions to this community-driven project. Let's collaborate to make it a valuable resource for ServiceNow developers and enthusiasts.
-
-🔔🔔🔔<br>
-**_CONTRIBUTORS must follow all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)_** or run the risk of having your Pull Requests labeled as spam.<br>
-🔔🔔🔔
-
-## We invite you to contribute!
-
-To contribute, just follow these steps:
-
-1. Fork this repo (you get a point just by forking!)
-2. Create a new branch on your fork
-3. Add/Update the repo
-4. Submit a pull request!
-
-That's it! More detailed contribution instructions can be found [here](CONTRIBUTING.md)
-
-## Leaderboard
-
-Looking for the old leaderboard? We've moved the leaderboard to the overarching [Hacktoberfest](https://github.com/ServiceNowDevProgram/Hacktoberfest#leaders) repository and have expanded its scope to all participating projects.
+```javascript
+var gr = new GlideRecord('your_table_name');
+gr.query();
+if (gr.next()) {
+    var fieldNames = getFieldNames(gr);
+    gs.info('Field Names: ' + fieldNames.join(', '));
+}

--- a/getFieldNames
+++ b/getFieldNames
@@ -1,0 +1,20 @@
+
+    getFieldNames(glideRecord) {
+
+		//Return if GlideRecord is empty
+        if (this.nil(glideRecord))
+            return;
+
+        //Check whether this is actually a valid GR and not something else
+		if (glideRecord instanceof GlideRecord == false)
+			return [];
+
+
+        var fieldNameArr = [];
+        var fields = glideRecord.getElements();
+        for (var i in fields) {
+            var element = fields[i];
+            fieldNameArr.push(element.getName());
+        }
+        return fieldNameArr;
+    }


### PR DESCRIPTION
### Summary
This pull request introduces a new utility function, `getFieldNames`, designed to retrieve the names of all fields in a given GlideRecord instance. This function enhances the flexibility of data handling in ServiceNow scripts.

### Changes Made
- Implemented the `getFieldNames` function that:
  - Validates the input to ensure it is a non-empty GlideRecord instance.
  - Returns an array of field names for the specified GlideRecord.

### Benefits
This utility allows developers to dynamically access field names in their GlideRecord instances, making it easier to manipulate data and improve code readability.

### Next Steps
Once this PR is reviewed and merged, developers can leverage the `getFieldNames` function to simplify their workflows involving GlideRecords.
