### PR TITLE
Add getObject Function to get JSON object of a GlideRecord

### DIFF
--- a/getJSONObject
+++ b/getJSONObject
@@ -1,0 +1,39 @@
+function getJSONObject(gr, desiredFields /* optional */) {
+    // Check whether this is actually a valid GlideRecord
+    if (!isValidGR(gr)) {
+        return {};
+    }
+
+    // Determine fields to retrieve
+    if (nil(desiredFields) || !isArray(desiredFields)) {
+        var gRU = new GlideRecordUtil();
+        desiredFields = gRU.getFields(gr); // Get fields using GlideRecordUtil
+    }
+
+    var fieldValues = {};
+    for (var i = 0; i < desiredFields.length; i++) {
+        var fieldName = desiredFields[i];
+        if (!gr.isValidField(fieldName)) {
+            continue; // Skip invalid fields
+        }
+
+        // Get the field value
+        var fieldValue = gr.getValue(fieldName);
+        fieldValues[fieldName] = gs.nil(fieldValue) ? '' : fieldValue; // Handle nil values
+    }
+
+    return fieldValues;
+}
+
+// Helper functions
+function isValidGR(gr) {
+    return gr instanceof GlideRecord && !gr.nil();
+}
+
+function nil(value) {
+    return value === null || value === undefined;
+}
+
+function isArray(value) {
+    return Array.isArray(value);
+}


### PR DESCRIPTION
### Summary
This pull request introduces an independent `getObject` function to facilitate the retrieval of field values from a GlideRecord instance. This standalone function can be easily reused across different scripts.

### Changes Made
- Implemented the `getObject` function that:
  - Accepts a GlideRecord instance and an optional array of desired fields.
  - Validates the input and retrieves values for specified or all fields if none are provided.
  - Skips invalid fields gracefully and handles empty values.

### Benefits
The independent `getObject` function enhances code modularity, allowing developers to extract field values from GlideRecords efficiently across various scripts.

### Next Steps
Once this PR is reviewed and merged, developers can incorporate the `getObject` function into their scripts for streamlined data handling in ServiceNow.
