### PR TITLE
Get users based on role

### DIFF
--- a/Background Scripts/listUsersHavingSpecificRole/readme.md
+++ b/Background Scripts/listUsersHavingSpecificRole/readme.md
@@ -1,1 +1,1 @@
-This function script will fetch all the users based on the role provided to the function and print a comma separated list.
+This function script will fetch all the users based on the role provided to the function and print a comma separated list. This function and encoded query is tested and verified on Xanadu release.

--- a/Background Scripts/listUsersHavingSpecificRole/readme.md
+++ b/Background Scripts/listUsersHavingSpecificRole/readme.md
@@ -1,0 +1,1 @@
+This function script will fetch all the users based on the role provided to the function and print a comma separated list.

--- a/Background Scripts/listUsersHavingSpecificRole/script.js
+++ b/Background Scripts/listUsersHavingSpecificRole/script.js
@@ -1,0 +1,14 @@
+function getUsersBasedOnrole(role){
+	var userGR = new GlideRecord('sys_user');
+	var roleGR = new GlideRecord('sys_user_has_role');
+	var itilUsers = [];
+	roleGR.addQuery('role.name', role);
+	roleGR.query();
+	
+	while (roleGR.next()) {
+		userGR.get(roleGR.user);
+		itilUsers.push(userGR.user_name.toString());
+	}
+  gs.info('Users with '+ role +' role: ' + itilUsers.join(', '));
+  }
+getUsersBasedOnrole('itil');

--- a/Background Scripts/listUsersHavingSpecificRole/script.js
+++ b/Background Scripts/listUsersHavingSpecificRole/script.js
@@ -1,14 +1,11 @@
 function getUsersBasedOnrole(role){
-	var userGR = new GlideRecord('sys_user');
-	var roleGR = new GlideRecord('sys_user_has_role');
 	var itilUsers = [];
-	roleGR.addQuery('role.name', role);
-	roleGR.query();
-	
-	while (roleGR.next()) {
-		userGR.get(roleGR.user);
+	var userGR = new GlideRecord('sys_user');
+	userGR.addEncodedQuery('roles.name=itil');
+	userGR.query();
+	while (userGR.next()) {
 		itilUsers.push(userGR.user_name.toString());
 	}
-  gs.info('Users with '+ role +' role: ' + itilUsers.join(', '));
-  }
+	gs.info('Users with '+ role +' role: ' + itilUsers.join(', '));
+}
 getUsersBasedOnrole('itil');


### PR DESCRIPTION
This function will provide the list of the users with specific roles assigned to them. The function is tested and in use by our team members. We are using it on daily basis on Xanadu and Washington release.