### PR TITLE
SW - auto close incident

### DIFF
--- a/Business Rules/Auto-Close Incident After Resolution/readme.md
+++ b/Business Rules/Auto-Close Incident After Resolution/readme.md
@@ -1,0 +1,19 @@
+This code snippet is a server-side script written in JavaScript for ServiceNow, designed to automatically close incidents that have been in the "Resolved" state for more than 3 days. 
+
+Summary of Code Functionality
+This script:
+Queries the Incident table to find incidents that are in the Resolved state and have been resolved for at least 3 days.
+For each incident that matches these criteria, it changes the state to Closed.
+The update() method commits these changes to the database, ensuring all qualifying incidents are automatically closed.
+
+1.GlideRecord is a ServiceNow class used to interact with tables in the database, allowing us to perform queries, insert, update, and delete records.
+2.Here, 'state' refers to the field name, and 'resolved' is the value we’re looking for (in the database, "Resolved" usually has an internal state value like 6, so it’s important to confirm the exact value if needed).
+3. gs.daysAgo(3) is a GlideSystem function that returns the date and time of exactly 3 days ago, allowing us to find incidents resolved before or on this date.
+4. It will execute the query with the conditions defined above. The query will return all incidents that meet the following:
+- Currently in the Resolved state.
+- Resolved at least 3 days ago.
+5. The while loop iterates through each record returned by the query. For every record that matches the conditions, this loop will execute the code inside its block.
+6. incident.next() loads the next record from the query result each time the loop runs.
+7. For each incident returned by the query, this line sets its state field to 7, which is the internal value for the Closed state in ServiceNow.
+8. Updating this field effectively changes the incident’s state to Closed.
+9. The update() function commits the new state value, ensuring the incident’s state is now Closed.

--- a/Business Rules/Auto-Close Incident After Resolution/script.js
+++ b/Business Rules/Auto-Close Incident After Resolution/script.js
@@ -1,0 +1,9 @@
+var incident = new GlideRecord('incident');
+incident.addQuery('state', 'resolved');
+incident.addQuery('resolved_at', '<=', gs.daysAgo(3));
+incident.query();
+
+while (incident.next()) {
+    incident.state = 7; // Closed
+    incident.update();
+}


### PR DESCRIPTION
This code snippet is a server-side script written in JavaScript for ServiceNow, designed to automatically close incidents that have been in the "Resolved" state for more than 3 days.