### PR TITLE
Auto-populate Short Description based on Category field value

### DIFF
--- a/Client Scripts/Auto-Populate Short Discription/Auto-pop_SD_Soumyadeep.js
+++ b/Client Scripts/Auto-Populate Short Discription/Auto-pop_SD_Soumyadeep.js
@@ -1,0 +1,22 @@
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+   if (isLoading || newValue === '') {
+      return;
+   }
+
+
+    // Define mappings for categories and corresponding short descriptions
+    var categoryToShortDescription = {
+        'hardware': 'Hardware is selected  ',
+        'software': 'Software is selected  ',
+        'network': 'Network is selected  ',
+        'database': 'Database is selected  '
+    };
+
+    // Update Short Description based on the selected category
+    if (categoryToShortDescription.hasOwnProperty(newValue)) {
+
+		var shortDescriptionField = g_form.getValue('short_description') || ''; // Get the Short Description field
+
+        g_form.setValue('short_description', categoryToShortDescription[newValue] + shortDescriptionField);
+    }
+}

--- a/Client Scripts/Auto-Populate Short Discription/readme_Soumyadeep.md
+++ b/Client Scripts/Auto-Populate Short Discription/readme_Soumyadeep.md
@@ -1,0 +1,3 @@
+This script will append a predefined prefix to the existing 'Short Description' value whenever a user selects a category from the provided options. 
+This will create a more informative short description.
+This code contains mappings for the category field values based on which the short description would be updated.


### PR DESCRIPTION
I have created a client script that will append a predefined prefix to the existing 'Short Description' value whenever a user selects a category from the provided options. This will create a more informative short description.
This code contains mappings for the category field values based on which the short description would be updated.