### PR TITLE
Send notification if the incident remains unassigned for more than 5 days

### DIFF
--- a/UI Actions/Send notification if the incident remains unassigned/readme.md
+++ b/UI Actions/Send notification if the incident remains unassigned/readme.md
@@ -1,0 +1,16 @@
+This is a UI Action script that adds a button to the Incident form. When clicked, it will check if the incident has been unassigned for more than 5 days. 
+If this condition is met, the button will trigger a notification to the manager of the incident's assignment group, informing them that the incident is still unassigned.
+
+Below are the conditions when UI action will be created:
+Table: Incident
+Show Insert: False
+Show Update: True
+Form Button: Checked (to add the button on the form)
+Condition: current.assigned_to.nil() && current.assignment_group
+
+The code contains below vaidations:
+- The script checks if the incident has been unassigned for more than 5 days by comparing the current date with the sys_created_on date using gs.daysAgo().
+- It verifies that the incident has an assignment group. If it does not, it displays an error message.
+- Queries the sys_user_group table to get the assignment group’s manager. If a manager is found, it sets up a notification to send an email directly to the manager.
+- Provides feedback to the user if the notification was sent or if there were issues (like missing assignment group or manager).
+- Redirects the user back to the current incident form after the UI Action runs.

--- a/UI Actions/Send notification if the incident remains unassigned/script.js
+++ b/UI Actions/Send notification if the incident remains unassigned/script.js
@@ -16,31 +16,25 @@ if (current.assignment_group.nil()) {
 // Get the assignment group's manager
 var assignmentGroup = new GlideRecord('sys_user_group');
 if (assignmentGroup.get(current.assignment_group)) {
-    var manager = assignmentGroup.getValue('manager'); // Fetches the sys_id of the manager field
+    var manager = assignmentGroup.getValue('manager');
 
     if (manager) {
-var userGR = new GlideRecord('sys_user'); // Access the sys_user table
-    var managerEmail = "";
-    if (userGR.get(assignedToEmail)) {
-        managerEmail = userGR.getValue('email'); // Retrieves the email field from the sys_user record
-    }
-if (managerEmail)
-{
- // Create a notification
-   var gr_sys_email = new GlideRecord('sys_email');
-        gr_sys_email.initialize();
-        gr_sys_email.setValue('type', 'send-ready');
-        gr_sys_email.setValue('subject', "Incident " + current.number + " is still unassigned");
-        gr_sys_email.setValue('recipients', managerEmail);
-        gr_sys_email.setValue('body', "The incident " + current.number + " has been unassigned for more than 5 days. Please assign it promptly.");
-        gr_sys_email.insert();
-}
-        gs.addInfoMessage("Notification about incident unassigned is sent to the assignment group's manager.");
+        // Create a notification
+        var notification = new GlideEmailOutbound();
+        notification.setFrom('no-reply@yourdomain.com');
+        notification.setSubject("Alert! Incident " + current.number + " is still unassigned");
+        notification.setBody("The incident " + current.number + " has been unassigned for more than 5 days. Please assign it promptly.");
+        notification.setTo(manager);
+
+        // Send the email
+        notification.send();
+
+        gs.addInfoMessage("Notification sent to the assignment group's manager.");
     } else {
         gs.addErrorMessage("The assignment group has no manager defined.");
     }
 } else {
-    gs.addErrorMessage("The incident has no assignment group.");
+    gs.addErrorMessage("Could not find the assignment group.");
 }
 
 action.setRedirectURL(current);

--- a/UI Actions/Send notification if the incident remains unassigned/script.js
+++ b/UI Actions/Send notification if the incident remains unassigned/script.js
@@ -1,0 +1,46 @@
+// Check if the incident has been unassigned for more than 5 days
+var unassignedDuration = gs.daysAgo(current.sys_created_on);
+if (unassignedDuration < 5) {
+    gs.addErrorMessage("The incident has been unassigned for less than 5 days.");
+    action.setRedirectURL(current);
+    return;
+}
+
+// Check if the incident has an assignment group
+if (current.assignment_group.nil()) {
+    gs.addErrorMessage("No assignment group is set for this incident.");
+    action.setRedirectURL(current);
+    return;
+}
+
+// Get the assignment group's manager
+var assignmentGroup = new GlideRecord('sys_user_group');
+if (assignmentGroup.get(current.assignment_group)) {
+    var manager = assignmentGroup.getValue('manager'); // Fetches the sys_id of the manager field
+
+    if (manager) {
+var userGR = new GlideRecord('sys_user'); // Access the sys_user table
+    var managerEmail = "";
+    if (userGR.get(assignedToEmail)) {
+        managerEmail = userGR.getValue('email'); // Retrieves the email field from the sys_user record
+    }
+if (managerEmail)
+{
+ // Create a notification
+   var gr_sys_email = new GlideRecord('sys_email');
+        gr_sys_email.initialize();
+        gr_sys_email.setValue('type', 'send-ready');
+        gr_sys_email.setValue('subject', "Incident " + current.number + " is still unassigned");
+        gr_sys_email.setValue('recipients', managerEmail);
+        gr_sys_email.setValue('body', "The incident " + current.number + " has been unassigned for more than 5 days. Please assign it promptly.");
+        gr_sys_email.insert();
+}
+        gs.addInfoMessage("Notification about incident unassigned is sent to the assignment group's manager.");
+    } else {
+        gs.addErrorMessage("The assignment group has no manager defined.");
+    }
+} else {
+    gs.addErrorMessage("The incident has no assignment group.");
+}
+
+action.setRedirectURL(current);

--- a/UI Actions/Send notification if the incident remains unassigned/script.js
+++ b/UI Actions/Send notification if the incident remains unassigned/script.js
@@ -21,7 +21,7 @@ if (assignmentGroup.get(current.assignment_group)) {
     if (manager) {
         // Create a notification
         var notification = new GlideEmailOutbound();
-        notification.setFrom('no-reply@yourdomain.com');
+        notification.setFrom('no-reply@xyz.com');
         notification.setSubject("Alert! Incident " + current.number + " is still unassigned");
         notification.setBody("The incident " + current.number + " has been unassigned for more than 5 days. Please assign it promptly.");
         notification.setTo(manager);


### PR DESCRIPTION
This UI Action button will notify the assignment group's manager if the incident is unassigned for more than 5 days, helping ensure timely assignment and resolution. 