### PR TITLE
Improve incident handling

### DIFF
--- a/GlideAggregate/Improve incident handling/readme.md
+++ b/GlideAggregate/Improve incident handling/readme.md
@@ -1,0 +1,21 @@
+Suppose you want to gather data about incident resolution in your system. 
+Specifically, you need to find the total number of incidents, the average time to resolution (in hours), and the number of incidents per assignment group. 
+This information can help analyze the efficiency of different groups and improve incident handling.
+
+Below are the added Aggregations:
+
+inc.addAggregate('COUNT') gets the total count of resolved incidents.
+inc.addAggregate('AVG', 'calendar_duration') calculates the average calendar duration for incident resolution (measured in hours).
+inc.addAggregate('COUNT', 'assignment_group') counts incidents per assignment group, and ga.groupBy('assignment_group') groups the result by assignment group to produce totals per group.
+
+Result:
+- It fetches total counts, average resolution time, and group-specific counts.
+- Logs the total number of resolved incidents and the average resolution time.
+- For each assignment group, it logs the group’s sys_id and the corresponding incident count.
+
+Benefits of Using GlideAggregate:
+- Reduces the number of queries and records you need to process, as it performs calculations at the database level.
+- Works well with large datasets, making it suitable for summary reports and dashboards.
+- Allows grouping and multiple aggregations (e.g., AVG, COUNT, MIN, MAX) on various fields in a single query.
+  
+This GlideAggregate example provides a consolidated view of incident resolution statistics, which can aid in optimizing group efficiency and improving response times.

--- a/GlideAggregate/Improve incident handling/script.js
+++ b/GlideAggregate/Improve incident handling/script.js
@@ -2,7 +2,7 @@
 var inc = new GlideAggregate('incident');
 
 // Filter for resolved incidents only
-inc.addQuery('state', 'resolved');
+inc.addQuery('state', 6); 
 
 // Add aggregations
 inc.addAggregate('COUNT');                    // Total number of incidents

--- a/GlideAggregate/Improve incident handling/script.js
+++ b/GlideAggregate/Improve incident handling/script.js
@@ -1,0 +1,38 @@
+// Create a GlideAggregate instance for the Incident table
+var inc = new GlideAggregate('incident');
+
+// Filter for resolved incidents only
+inc.addQuery('state', 'resolved');
+
+// Add aggregations
+inc.addAggregate('COUNT');                    // Total number of incidents
+inc.addAggregate('AVG', 'calendar_duration'); // Average resolution time in hours
+inc.addAggregate('COUNT', 'assignment_group'); // Count of incidents per assignment group
+inc.groupBy('assignment_group'); // Group by assignment group to get the count per group
+inc.query();
+
+var totalIncidents = 0;
+var averageResolution = 0;
+var results = [];
+
+while (inc.next()) {
+    totalIncidents = inc.getAggregate('COUNT');
+    averageResolution = inc.getAggregate('AVG', 'calendar_duration');
+
+    // Get assignment group and incident count per group
+    var groupSysId = inc.assignment_group.toString();
+    var groupIncidentCount = inc.getAggregate('COUNT', 'assignment_group');
+
+    results.push({
+        groupSysId: groupSysId,
+        groupIncidentCount: groupIncidentCount
+    });
+}
+
+// Display results in logs
+gs.info("Total Resolved Incidents are: " + totalIncidents);
+gs.info("Average Resolution Time (hours) is: " + averageResolution);
+
+results.forEach(function(result) {
+    gs.info("Assignment Group: " + result.groupSysId + " | Incident Count: " + result.groupIncidentCount);
+});


### PR DESCRIPTION
Suppose you want to gather data about incident resolution in your system. Specifically, you need to find the total number of incidents, the average time to resolution (in hours), and the number of incidents per assignment group. This information can help analyze the efficiency of different groups and improve incident handling.

This GlideAggregate example provides a consolidated view of incident resolution statistics, which can aid in optimizing group efficiency and improving response times.

It fetches total counts, average resolution time, and group-specific counts.
Logs the total number of resolved incidents and the average resolution time.
For each assignment group, it logs the group’s sys_id and the corresponding incident count.