### PR TITLE
Prevent unnecessary notifications from being sent out

### DIFF
--- a/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
+++ b/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
@@ -10,7 +10,7 @@ emailGR.query();
 while (emailGR.next()) {
     emailGR.state = "ignored"; //setting state to "ignored"
     emailGR.type = 'send-ignored'; // Set the type to 'ignored'
-    emailGR.update(); // Save the changes
+    emailGR.updateMultiple(); // Save the changes
 }
 
 gs.info('All relevant emails have been marked as ignored.');

--- a/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
+++ b/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
@@ -1,16 +1,12 @@
-// Create a GlideRecord object for the 'sys_email' table
 var emailGR = new GlideRecord('sys_email');
 
-// Query for the emails you want to ignore (adjust the query as needed)
-emailGR.addQuery('state', 'ready'); // only those mails which are ready to send
-emailGR.addEncodedQuery("sys_created_onONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()"); // Optional query to set timeline if not required we can comment this.
-emailGR.query();
+// Query for the emails you want to ignore
+emailGR.addQuery('state', 'ready'); // Only emails that are ready to send
+emailGR.addEncodedQuery("sys_created_onONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()"); // Optional timeline filter
 
-// Loop through the results and mark them as 'Ignored'
-while (emailGR.next()) {
-    emailGR.state = "ignored"; //setting state to "ignored"
-    emailGR.type = 'send-ignored'; // Set the type to 'ignored'
-    emailGR.updateMultiple(); // Save the changes
-}
+// Set the fields to ignore and update all matching records at once
+emailGR.setValue('state', 'ignored'); // Set state to "ignored"
+emailGR.setValue('type', 'send-ignored'); // Set type to 'send-ignored'
+emailGR.updateMultiple(); // Bulk update all matching records
 
 gs.info('All relevant emails have been marked as ignored.');

--- a/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
+++ b/Background Scripts/Prevent unnecessary notifications from being sent out/Prevent_unnecessary_notifications_from_being_sent_out.js
@@ -1,0 +1,16 @@
+// Create a GlideRecord object for the 'sys_email' table
+var emailGR = new GlideRecord('sys_email');
+
+// Query for the emails you want to ignore (adjust the query as needed)
+emailGR.addQuery('state', 'ready'); // only those mails which are ready to send
+emailGR.addEncodedQuery("sys_created_onONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()"); // Optional query to set timeline if not required we can comment this.
+emailGR.query();
+
+// Loop through the results and mark them as 'Ignored'
+while (emailGR.next()) {
+    emailGR.state = "ignored"; //setting state to "ignored"
+    emailGR.type = 'send-ignored'; // Set the type to 'ignored'
+    emailGR.update(); // Save the changes
+}
+
+gs.info('All relevant emails have been marked as ignored.');

--- a/Background Scripts/Prevent unnecessary notifications from being sent out/readme.md
+++ b/Background Scripts/Prevent unnecessary notifications from being sent out/readme.md
@@ -1,0 +1,15 @@
+Created a background script to prevent unnecessary notifications from being sent out. 
+It helps in managing the volume of emails being sent so that we do not send the notifications even by mistake. 
+This script is mostly used in dev or uat to avoid any notifications being sent from lower instances.
+
+We are querying the sys_email table to find all the emails with below queries:
+--> emails with state as "ready"
+--> emails that were created on today (optional query, if not added all the mails with state as "ready" will be considered for getting ignored.) 
+
+Post query we are setting as below:
+--> state of the email to "ignored"
+--> type of the email to "send-ignored"
+
+After setting the fields we are updating the records.
+
+Please be cautious while using the script in Production environment.


### PR DESCRIPTION
Created a background script to prevent unnecessary notifications from being sent out. It helps in managing the volume of emails being sent so that we do not send the notifications even by mistake. This script is mostly used in dev or uat to avoid any notifications being sent from lower instances.