### PR TITLE
Add Automated Role Assignment Based on User Department

### DIFF
--- a/UserManagement/Automate Role Assignment for New User/README.md
+++ b/UserManagement/Automate Role Assignment for New User/README.md
@@ -1,0 +1,11 @@
+This snippet assigns specific roles to users based on their department within ServiceNow. 
+
+Departments are matched against a predefined dictionary, and roles are applied accordingly. To modify, update the `rolesByDepartment` dictionary with your organization’s department-role mappings. 
+```
+var rolesByDepartment = {
+        <department_name> : [role_1, role_2]
+    };
+```
+
+
+This script ensures automatic and consistent role assignment, streamlining access control for large teams.

--- a/UserManagement/Automate Role Assignment for New User/autoRoleAssignment.js
+++ b/UserManagement/Automate Role Assignment for New User/autoRoleAssignment.js
@@ -1,0 +1,22 @@
+// Script to automatically assign roles based on user department
+(function executeRule(current, previous /*null when async*/) {
+    var department = current.department.getDisplayValue();
+    
+    // Define roles by department
+    var rolesByDepartment = {
+        "IT": ["itil", "asset"],
+        "HR": ["hr_manager", "employee"],
+        "Finance": ["finance_analyst", "approver"]
+    };
+    
+    // Remove existing roles
+    current.roles = [];
+    
+    // Assign new roles based on department
+    if (rolesByDepartment[department]) {
+        rolesByDepartment[department].forEach(function(role) {
+            current.roles.add(role);
+        });
+        current.update();
+    }
+})(current, previous);


### PR DESCRIPTION
This snippet assigns specific roles to users based on their department within ServiceNow. It will ensure automatic and consistent role assignment, streamlining access control for large teams.
