### PR TITLE
Create Reference field value update from CI relationship connection.js

### DIFF
--- a/Background Scripts/Reference field value update from CI relationship connection.js
+++ b/Background Scripts/Reference field value update from CI relationship connection.js
@@ -1,0 +1,29 @@
+var updatedSysIds = [];
+var notUpdatedSysIds = [];
+
+var gr = new GlideRecord('< table_name >');
+gr.addQuery('< query condition >');
+gr.query();
+
+while (gr.next()) {
+
+    var relCi = new GlideRecord('cmdb_rel_ci');
+    relCi.addQuery('child', gr.sys_id);
+    relCi.addQuery('parent.sys_class_name', '< backend name of the table to which the reference field is referred to >');
+    relCi.query();
+
+    if (relCi.next()) {
+        // Update the reference field with the referenced table's sys_id
+        gr.< reference field backend name > = relCi.parent.sys_id;
+        gr.setWorkflow(false); 
+        gr.update();
+        updatedSysIds.push(gr.sys_id.toString()); // Add to updated list
+    } 
+	else {
+        notUpdatedSysIds.push(gr.sys_id.toString()); // Add to not updated list
+    }
+}
+
+// Print the sys_ids of the records updated and not updated
+gs.print("Updated records sys_ids: " + updatedSysIds.join(', '));
+gs.print("Not updated records sys_ids: " + notUpdatedSysIds.join(', '));

--- a/Background Scripts/readME.md
+++ b/Background Scripts/readME.md
@@ -1,0 +1,2 @@
+In this piece of code, we are querying a table for some records and then updating a particular reference field's value of those records to the value of the specific parent class to which it has a cmdb_rel_ci relationship.
+We are also printing the sys_ids pf the records which would be updated and the ones that would be skipped.


### PR DESCRIPTION
In this piece of code, we are querying a table for some records and then updating the reference field value of those records to the value of the specific parent class to which it has a cmdb_rel_ci relationship. We are also printing the sys_ids pf the records which would be updated and the ones that would be skipped.