### PR TITLE
Adding placeholder text on Resolution notes Client Script

### DIFF
--- a/Client Scripts/Adding Placeholder on Resolution Notes/README.md
+++ b/Client Scripts/Adding Placeholder on Resolution Notes/README.md
@@ -1,0 +1,15 @@
+# Adding Placeholder Text in Resolution Notes
+
+To maintain consistency and ensure specific information is captured in resolution notes, process owners may require fulfillers to follow a predefined format when resolving tickets.
+
+By adding **placeholder** text in the resolution notes, fulfillers are reminded of the required information(e.g., Root cause, Steps taken, Resolution provided), reducing the risk of missing important details. The placeholder disappears as soon as the fulfiller begins entering their notes, ensuring it doesn't interfere with their input.
+
+## How It Works
+
+### When?
+- The placeholder text is automatically added when the state of the ticket changes to Resolved (6).
+
+### What Happens?
+- A placeholder text appears in the resolution notes field to guide the fulfiller.
+- As soon as the fulfiller starts typing, the placeholder disappears.
+- This ensures consistency and alignment with the process requirements.

--- a/Client Scripts/Adding Placeholder on Resolution Notes/script.js
+++ b/Client Scripts/Adding Placeholder on Resolution Notes/script.js
@@ -1,0 +1,10 @@
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+    if (isLoading || newValue === '') {
+        return;
+    }
+    var res = g_form.getElement('close_notes');
+    if (newValue == 6)
+        res.placeholder = "1. Root Cause" + "\n" + "2. Steps taken" + "\n" + "3. Resolution provided"; //Placeholder text as required
+    else
+        res.placeholder = "";
+}


### PR DESCRIPTION
I added the folder code-snippets->client scripts -> Adding Placeholder on Resolution Notes

I’ve implemented a client script that adds placeholder text in the resolution notes field when the state changes to Resolved. The placeholder guides fulfillers to maintain consistency and disappears as soon as they start typing. This ensures that essential information is not missed while resolving tickets.