### PR TITLE
Fix Script to Remove Leading and Trailing Spaces from a field in bulk records

### DIFF
--- a/Fix scripts/Remove leading and trailing spaces/README.md
+++ b/Fix scripts/Remove leading and trailing spaces/README.md
@@ -1,0 +1,7 @@
+## Fix script to remove leading and trailing spaces from a field in bulk
+
+- we often encounter in a situation that a field has leading or trailing spaces and we want to remove it
+- This fix script helps to remove leading and trailing spaces from a field in bulk number.
+- Just for an example I have taken incident table and short description as a field.
+- feel free to modify and use it as per your requirement.
+  

--- a/Fix scripts/Remove leading and trailing spaces/RemoveLeadingTrailingSpaces.js
+++ b/Fix scripts/Remove leading and trailing spaces/RemoveLeadingTrailingSpaces.js
@@ -1,0 +1,43 @@
+var page = 1;
+var count = 0;
+var infoMsg = 'Fix Script to remove leading or trailing spaces from short_description. \n';
+var sd = '';  //sd inshort for shortdescription 
+
+
+var regExSpacecheck = /^\s+|\s+$/g;  //regular expression to check if a sentence has leading and trailing spaces.
+
+var grInc = new GlideRecord('incident');
+grInc.addEncodedQuery('short_descriptionISNOTEMPTY');
+grInc.query();
+while (grInc.next()) {
+
+    if (regExSpacecheck.test(grInc.short_description)) {
+
+        infoMsg += 'incident record found with leading or trailing space for short_description: ' + grInc.sys_id + '\n';
+        infoMsg += 'Sd ' + grInc.short_description + 'Contains leading or trailing spaces \n';
+        sd = grInc.short_description;
+        sd = sd.trim();    //trimmed value of short description
+        infoMsg += 'sd is ' + sd + '\n';
+
+        if (regExSpacecheck.test(sd)) {
+            infoMsg += 'sd: ' + sd + ' still has a trailing space\n';
+        } else {
+            infoMsg += 'sd: ' + sd + ' no longer contains trailing space \n';
+        }
+        //Replace the value for u_location_svid with the trimmed version
+        grInc.setValue('short_description', sd);
+        grInc.setWorkflow(false);
+        grInc.update();
+
+        count++;
+
+        if (count == 50) {
+            gs.info(infoMsg);
+            page++;
+            count = 0;
+            infoMsg = 'Fix Script to remove leading or trailing spaces from short_description  (' + page + ')\n';
+        }
+
+    }
+
+}


### PR DESCRIPTION
I have added a fix script to help get rid of removing spaces from leading and trailing manually for a field from thousands of records. 

This fix script will help in removing leading and trailing spaces from a field in bulk records. 
to give an example I have used incident table and short description as a field, you can modify it based on your requirement.