### PR TITLE
Open Record producer from Workspace and auto-populate data on the opened record producer

### DIFF
--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/OpenItem.js
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/OpenItem.js
@@ -1,0 +1,25 @@
+/* 
+UI Action
+   Client - true
+   action name - open_item
+   show update - true ( As per your requirement)
+   onClick - openItem();
+   Workspace Form button - true
+   Format for Configurable Workspace - true 
+*/
+
+//Workspace client script: 
+function onClick() {
+    var result = g_form.submit('open_item');
+    if (!result) {
+        return;
+    }
+    result.then(function() {
+        var params = {};
+        params.sysparm_parent_sys_id = g_form.getUniqueValue();
+        params.sysparm_shortDescription = g_form.getValue('short_description');
+        //add params as required, These params can be parsed and used in the record producer.
+        g_service_catalog.openCatalogItem('sc_cat_item', 'recordproducer_sysid_here', params); 
+        //Use the record producer sys_id in second parameter.
+    });
+}

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
@@ -1,3 +1,10 @@
+/*
+Catalog Client script.
+   Name - ParseURL
+   Type - Onload
+   Applies on catalog item view - true
+*/
+
 function onLoad() {
 
   
@@ -19,8 +26,6 @@ function onLoad() {
 	}
 }
 /*
-
 pass the parameter name which was used in the ui action to parse the value here.
-
-Example - parseURL('sysparm_description)
+Example - parseURL('sysparm_description) as I am passing description value in the params from ui action.
 */

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
@@ -1,0 +1,26 @@
+function onLoad() {
+
+  
+	g_form.setValue('task',parseURL('sysparm_parent_sys_id'));
+	g_form.setValue('description',parseURL('sysparm_description));
+	
+	function parseURL(paramName) {
+		
+		var url = decodeURIComponent(top.location.href); //Get the URL and decode it
+		var workspaceParams = url.split('extra-params/')[1]; //Split off the url on Extra params
+		var allParams = workspaceParams.split('/'); //The params are split on slashes '/'
+		
+		//Search for the parameter requested
+		for (var i=0; i< allParams.length; i++) {
+			if(allParams[i] == paramName) {
+				return allParams[i+1];
+			}
+		}
+	}
+}
+/*
+
+pass the parameter name which was used in the ui action to parse the value here.
+
+Example - parseURL('sysparm_description)
+*/

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/ParseUrl.js
@@ -1,5 +1,5 @@
 /*
-Catalog Client script.
+Catalog Client script on the record producer/catalog item you want to open from ui action
    Name - ParseURL
    Type - Onload
    Applies on catalog item view - true

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
@@ -1,14 +1,18 @@
+When we want to open a catalog item with details from current record and map it to the opened catalog form then we can use this code.
 
-This UI Action and catalog client script Redirects you to the record producer or catalog item( based on the sys id provided) and auto-populates the fields from the parent record to the catalog item/record producer.
+This UI Action and catalog client script Redirects you to the record producer or catalog item( based on the sys id provided) and auto-populates the fields from the parent record to the catalog item/record producer variables.
 
 1. UI Action
    Client - true
    action name - open_item
    show update - true ( As per your requirement)
    onClick - openItem();
-3. Catalog Client script.
+   Workspace Form button - true
+   Format for Configurable Workspace - true 
+
+2. Catalog Client script.
    Type - Onload
    Applies on catalog item view - true
    Name - ParseURL
 
-Note : Above UI Action works in Configurable workspce and opens the catalog item/record producer in workspace itself
+Note : Above UI Action works in Configurable workspace and opens the catalog item/record producer in workspace itself.

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
@@ -1,0 +1,14 @@
+
+This UI Action and catalog client script Redirects you to the record producer or catalog item( based on the sys id provided) and auto-populates the fields from the parent record to the catalog item/record producer.
+
+1. UI Action
+   Client - true
+   action name - open_item
+   show update - true ( As per your requirement)
+   onClick - openItem();
+3. Catalog Client script.
+   Type - Onload
+   Applies on catalog item view - true
+   Name - ParseURL
+
+Note : Above UI Action works in Configurable workspce and opens the catalog item/record producer in workspace.

--- a/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
+++ b/UI Actions/Open Record producer from Form Button In Configurable workspace/readme.md
@@ -11,4 +11,4 @@ This UI Action and catalog client script Redirects you to the record producer or
    Applies on catalog item view - true
    Name - ParseURL
 
-Note : Above UI Action works in Configurable workspce and opens the catalog item/record producer in workspace.
+Note : Above UI Action works in Configurable workspce and opens the catalog item/record producer in workspace itself


### PR DESCRIPTION
When we want to open a catalog item or record producer with details from current record and map it to the opened catalog form then we can use this code.

This UI Action and catalog client script Redirects you to the record producer or catalog item( based on the sys id provided) and auto-populates the fields from the parent record to the catalog item/record producer variables.

