### PR TITLE
Set update sets to complete

### DIFF
--- a/Background Scripts/Set update sets to Complete/readme.md
+++ b/Background Scripts/Set update sets to Complete/readme.md
@@ -1,0 +1,5 @@
+Executing this script would help the administrators to set all the inprogress update sets to complete state.
+
+Most of the times this script comes in handy before setting up the instance to patching or upgradation as during that time updatesets need to be set complete and a backup has to be taken.
+
+Be cautious while using this script as this sets all the update sets whose state is inprogress and name does not start with "default" to complete.

--- a/Background Scripts/Set update sets to Complete/set_update_sets_to_complete.js
+++ b/Background Scripts/Set update sets to Complete/set_update_sets_to_complete.js
@@ -1,7 +1,7 @@
 //note : this script is going to mark all the update sets that are in progress to complete so make sure the query meets your requirements.
 
 var gr = new GlideRecord("sys_update_set"); //querying the update sets table to check update sets which are in progress  
-gr.addQuery("state","in progress");
+gr.addEncodedQuery("state=in progress^nameNOT LIKEdefault");
 
 gr.setValue("state","complete"); //marking them to complete and updating multiple records using updateMultiple()
 gr.updateMultiple();

--- a/Background Scripts/Set update sets to Complete/set_update_sets_to_complete.js
+++ b/Background Scripts/Set update sets to Complete/set_update_sets_to_complete.js
@@ -1,0 +1,7 @@
+//note : this script is going to mark all the update sets that are in progress to complete so make sure the query meets your requirements.
+
+var gr = new GlideRecord("sys_update_set"); //querying the update sets table to check update sets which are in progress  
+gr.addQuery("state","in progress");
+
+gr.setValue("state","complete"); //marking them to complete and updating multiple records using updateMultiple()
+gr.updateMultiple();


### PR DESCRIPTION
Update sets which are inprogress state shall be set to complete using this background script if it matches the below conditions:
1) State should be inprogress
2) Name should not contain "default"

This helps the administrators to set the update sets state to complete state.