### PR TITLE
Valid mobile number

### DIFF
--- a/Client Scripts/validate phone number/Readme.md
+++ b/Client Scripts/validate phone number/Readme.md
@@ -1,0 +1,2 @@
+This script is triggered when the phone field changes. 
+It uses to validate the length of the phone number. If it exceeds the maximum length, it displays an error message and clears the field.

--- a/Client Scripts/validate phone number/validateLength.js
+++ b/Client Scripts/validate phone number/validateLength.js
@@ -1,0 +1,13 @@
+// Client Script: Validate Length
+// Table: sys_user
+// Type: onChange
+// Field: phone
+
+function onChange(control, oldValue, newValue, isLoading) {
+    if (isLoading || newValue === '') return;
+
+  if (newValue.length>12) {
+    g_form.showFieldMsg('phone', 'Phone number should have a maximum of 12 charecters', 'error');
+        g_form.setValue('phone', '');
+    }
+}


### PR DESCRIPTION
It is used to validate the length of the phone number. If it exceeds the maximum length, it displays an error message and clears the field.