### PR TITLE
Add code snippet to manage group membership automatically via API

### DIFF
--- a/Business Rules/Automatic Group Membership Updates via API/README.md
+++ b/Business Rules/Automatic Group Membership Updates via API/README.md
@@ -1,0 +1,18 @@
+# Overview
+This code snippet helps ServiceNow developers manage group memberships automatically by integrating with an external API. It retrieves group membership data from a specified API endpoint and updates user-group relationships in ServiceNow accordingly. 
+
+This is useful for organizations where user groups are managed dynamically in external systems, and developer want a seamless and up-to-date integration with ServiceNow.
+
+# How It Works
+The script:
+- Fetches API Data: It connects to an external API (specified by the `apiEndpoint` variable) to retrieve the current group membership details.
+- Parses API Response: The response is parsed to extract user information (based on email) and group identifiers.
+- Updates Group Memberships:
+    - For each member in the response, the script queries the `sys_user` table to locate the user in ServiceNow based on their email address.
+    - Once a user is found, the script creates a new record in the `sys_user_grmember` table, associating the user with the appropriate group.
+
+# Implementation
+- Define the `apiEndpoint` URL, replacing `https://your-group-api.com/members` with the actual endpoint from which group membership data will be fetched.
+- Ensure that any necessary authentication for the API is configured, such as API keys or tokens.
+- This script uses email as a unique identifier for users. Adjust `userGR.addQuery('email', member.email)`; if another identifier is needed.
+- Deploy the script as a Business Rule in ServiceNow, setting the appropriate table and conditions under which it should execute. For example, it could run on a schedule or be triggered by a specific update.

--- a/Business Rules/Automatic Group Membership Updates via API/autoGroupMembershipUpdate.js
+++ b/Business Rules/Automatic Group Membership Updates via API/autoGroupMembershipUpdate.js
@@ -1,0 +1,25 @@
+// Script to update group memberships based on API data
+(function executeRule(current, previous /*null when async*/) {
+    var apiEndpoint = 'https://your-group-api.com/members';
+    var request = new sn_ws.RESTMessageV2();
+    request.setEndpoint(apiEndpoint);
+    request.setHttpMethod('GET');
+
+    var response = request.execute();
+    var responseData = JSON.parse(response.getBody());
+    
+    // Update group memberships
+    responseData.members.forEach(function(member) {
+        var userGR = new GlideRecord('sys_user');
+        userGR.addQuery('email', member.email);
+        userGR.query();
+        
+        if (userGR.next()) {
+            var groupMembership = new GlideRecord('sys_user_grmember');
+            groupMembership.initialize();
+            groupMembership.group = member.group_id;
+            groupMembership.user = userGR.sys_id;
+            groupMembership.insert();
+        }
+    });
+})(current, previous);


### PR DESCRIPTION
### Overview
This code snippet helps ServiceNow developers manage group memberships automatically by integrating with an external API. It retrieves group membership data from a specified API endpoint and updates user-group relationships in ServiceNow accordingly. 

This is useful for organisations where user groups are managed dynamically in external systems, and developer want a seamless and up-to-date integration with ServiceNow.

### Folder structure:
- `Business Rules/Automatic Group Membership Updates via API/autoGroupMembershipUpdate.js`
- `Business Rules/Automatic Group Membership Updates via API/README.md`

P/S: @Lacah or any maintainers that will review this PR, please help to point me to the appropriate top-level folder that suitable with it, but I think it's match with `Business Rules` folder. 

The `Code Snippets` repo is a bit big so sometime I have a confusion where I should put my code. 