### PR TITLE
Add code snippet to backup Critical Table Data

### DIFF
--- a/Business Rules/Backup Critical Table Data/README.md
+++ b/Business Rules/Backup Critical Table Data/README.md
@@ -1,0 +1,12 @@
+# Overview
+This snippet enables the backup of critical table data (such as task or incident records) to an external storage solution. It’s a valuable tool for developers looking to ensure redundancy and backup for sensitive data within ServiceNow.
+
+# How It Works
+- Data Extraction: Collects key record fields (such as `sys_id`, `number`, `short_description`) from `current`.
+- API Call: Sends a `POST` request with record data to an external backup endpoint.
+- Logging: Outputs API response for monitoring.
+
+# Implementation
+1. Update the `setEndpoint` URL to match your backup API endpoint.
+2. Modify the `recordData` with table data structure as needed.
+3. Ensure the Business Rule is triggered on the appropriate conditions (e.g., on record insert/update) in the target table.

--- a/Business Rules/Backup Critical Table Data/README.md
+++ b/Business Rules/Backup Critical Table Data/README.md
@@ -1,5 +1,5 @@
 # Overview
-This snippet enables the backup of critical table data (such as task or incident records) to an external storage solution. It’s a valuable tool for developers looking to ensure redundancy and backup for sensitive data within ServiceNow.
+This ServiceNow script automates backing up critical record data (such as task or incident records) to an external storage solution. Designed to run as a Business Rule, it helps maintain redundancy for sensitive information by copying specific record details to a backup API whenever a record is created or modified.
 
 # How It Works
 - Data Extraction: Collects key record fields (such as `sys_id`, `number`, `short_description`) from `current`.

--- a/Business Rules/Backup Critical Table Data/backupCriticalTableData.js
+++ b/Business Rules/Backup Critical Table Data/backupCriticalTableData.js
@@ -1,0 +1,18 @@
+// Script to back up critical table data to external storage
+(function executeRule(current, previous /*null when async*/) {
+    var recordData = {
+        sys_id: current.sys_id.toString(),
+        number: current.number.toString(),
+        short_description: current.short_description.toString()
+    };
+    
+    // Call external API to store data
+    var request = new sn_ws.RESTMessageV2();
+    request.setEndpoint('https://your-backup-api.com/backup');
+    request.setHttpMethod('POST');
+    request.setRequestBody(JSON.stringify(recordData));
+    
+    var response = request.execute();
+    gs.info("Backup response: " + response.getBody());
+})(current, previous);
+


### PR DESCRIPTION
### Overview
This ServiceNow script automates backing up critical record data (such as task or incident records) to an external storage solution. It helps developers maintaining redundancy for sensitive information by copying specific record details to a backup API whenever a record is created or modified.

### Folder structure
- `Business Rules/Backup Critical Table Data/backupCriticalTableData.js`
- `Business Rules/Backup Critical Table Data/README.md`

P/S: Similar with the PR #1580, I hope this script is suitable with Business Rules folder, otherwise please help to point me to appropriate folder for it. 

Thanks a lot!!
