### PR TITLE
Business rule for fetching reference field value from higher-level parents

### DIFF
--- a/Business Rules/Fetching reference field value from higher-level parents/Fetching reference field value from higher-level parents.js
+++ b/Business Rules/Fetching reference field value from higher-level parents/Fetching reference field value from higher-level parents.js
@@ -1,0 +1,12 @@
+// In this before insert or update Business Rule, we are fetching a reference field value from higher-level parents in hierarchy when there is a field containing the parent record in the children and our use-case reference field is present in all the tables in hierarchy
+// I would be referring to "reference field name we want to populate" as "r1"
+// I would be referring to "reference field containing parent record" as "parent"
+
+
+(function executeRule(current, previous /*null when async*/ ) {
+    if (current.r1 == "" && !JSUtil.nil(current.parent.r1)) // Populate 'use-case reference field' from parent's value for the reference field'
+        current.r1 = current.parent.r1;
+    else if (current.< reference field name we want to populate > == "" && !JSUtil.nil(current.parent.parent.r1)) // Populate 'use-case reference field' from 'parent of parent' 
+        current.r1 = current.parent.parent.r1;
+
+})(current, previous);

--- a/Business Rules/Fetching reference field value from higher-level parents/readme.md
+++ b/Business Rules/Fetching reference field value from higher-level parents/readme.md
@@ -1,0 +1,12 @@
+This is a "**before insert/update**" Business Rule
+We are fetching a reference field value from higher-level parents in hierarchy 
+when there is a field containing the parent record in the children and 
+our use-case reference field is present in all the tables in hierarchy
+
+In the code, we are referring to "reference field name we want to populate" as "_r1_"
+In the code, we are referring to "reference field containing parent record" as "_parent_"
+
+The "**JSUtil.nil**" is being used to check for empty/null value for the field.
+
+
+Through the code we are checking the empty value of the use-case reference field and dot walking to parents and fetching the value from them if it exists


### PR DESCRIPTION
This is a "before insert/update" Business Rule We are fetching a reference field value from higher-level parents in hierarchy when there is a field containing the parent record in the children and our use-case reference field is present in all the tables in hierarchy

Through the code we are checking the empty value of the use-case reference field and dot walking to parents and fetching the value from them if it exists