### PR TITLE
added custom sla breach script

### DIFF
--- a/SlaBreach/readme.md
+++ b/SlaBreach/readme.md
@@ -1,0 +1,7 @@
+# Custom SLA Breach Alert
+
+This script monitors SLAs and sends a notification to assignees if an SLA is about to breach within the next hour. It allows users to take preemptive action to meet SLA commitments.
+
+## Usage
+- Place this script in a Script Include or scheduled job to monitor SLA breaches.
+- Customize the query for different SLA thresholds.

--- a/SlaBreach/script.js
+++ b/SlaBreach/script.js
@@ -1,0 +1,16 @@
+(function alertSLABreach() {
+    // Query for tasks with SLAs nearing breach within 1 hour
+    var sla = new GlideRecord('task_sla');
+    sla.addEncodedQuery('breach_timeRELATIVELE@hour@1');
+    sla.query();
+
+    // Send alert notification
+    while (sla.next()) {
+        var taskNumber = sla.task.number;
+        var assignedUser = sla.task.assigned_to;
+        
+        if (assignedUser) {
+            gs.eventQueue("custom.sla.breach.alert", sla.task, assignedUser, taskNumber);
+        }
+    }
+})();


### PR DESCRIPTION
# Custom SLA Breach Alert

This script monitors SLAs and sends a notification to assignees if an SLA is about to breach within the next hour. It allows users to take preemptive action to meet SLA commitments.

## Usage
- Place this script in a Script Include or scheduled job to monitor SLA breaches.
- Customize the query for different SLA thresholds.
