### PR TITLE
added user account cleanup script

### DIFF
--- a/UserAccountCleanup/readme.md
+++ b/UserAccountCleanup/readme.md
@@ -1,0 +1,7 @@
+# User Account Cleanup
+
+This script automatically disables user accounts that have been inactive for more than six months, maintaining a secure and manageable user database.
+
+## Usage
+- Use this script in a scheduled job to regularly clean up inactive accounts.
+- Modify the `last_login_time` query as needed for different inactivity thresholds.

--- a/UserAccountCleanup/script.js
+++ b/UserAccountCleanup/script.js
@@ -1,0 +1,12 @@
+(function cleanupInactiveUsers() {
+    // Query for users inactive for over 6 months
+    var user = new GlideRecord('sys_user');
+    user.addEncodedQuery('last_login_timeRELATIVELE@dayofweek@-180');
+    user.query();
+
+    // Disable each inactive user account
+    while (user.next()) {
+        user.active = false;
+        user.update();
+    }
+})();


### PR DESCRIPTION
# User Account Cleanup

This script automatically disables user accounts that have been inactive for more than six months, maintaining a secure and manageable user database.

## Usage
- Use this script in a scheduled job to regularly clean up inactive accounts.
- Modify the `last_login_time` query as needed for different inactivity thresholds.
