### PR TITLE
Reject Approvals Older Than One Year

### DIFF
--- a/Scheduled Jobs/Reject approvals created before an year/Reject Approvals Created Before an Year.js
+++ b/Scheduled Jobs/Reject approvals created before an year/Reject Approvals Created Before an Year.js
@@ -1,0 +1,7 @@
+var grAppr = new GlideRecord("sysapproval_approver");
+grAppr.addEncodedQuery("sys_created_on<javascript:gs.beginningOfLast12Months()^state=requested");
+grAppr.query();
+while(grAppr.next()){
+	grAppr.setValue('state', 'rejected');
+	grAppr.update();
+}

--- a/Scheduled Jobs/Reject approvals created before an year/readme.md
+++ b/Scheduled Jobs/Reject approvals created before an year/readme.md
@@ -1,15 +1,7 @@
-**Creating a GlideRecord Object:**
-var grAppr = new GlideRecord("sysapproval_approver");
+**Script Purpose:**
+This script helps you manage approval records in ServiceNow. It searches for approval requests in the sysapproval_approver table that were created more than 12 months ago and are currently marked as "requested." The script then updates these records to change their status to "rejected."
 
-**Adding an Encoded Query:**
-grAppr.addEncodedQuery("sys_created_on<javascript:gs.beginningOfLast12Months()^state=requested");
+**How to Use This Script**
+Where to Run It: You can execute this script in a server-side context, such as a Scheduled Jobs, Script Include, or Background Script. Make sure you have the necessary permissions to access and update records in the sysapproval_approver table.
 
-**Executing the Query:**
-grAppr.query();
-
-**Iterating Through the Results:**
-while(grAppr.next()){
-
-**Updating the State:**
-grAppr.setValue('state', 'rejected');
-grAppr.update();
+**Be Cautious:** The script will automatically find the relevant approval records and update all matching records, so double-check the criteria before executing it.

--- a/Scheduled Jobs/Reject approvals created before an year/readme.md
+++ b/Scheduled Jobs/Reject approvals created before an year/readme.md
@@ -1,0 +1,15 @@
+**Creating a GlideRecord Object:**
+var grAppr = new GlideRecord("sysapproval_approver");
+
+**Adding an Encoded Query:**
+grAppr.addEncodedQuery("sys_created_on<javascript:gs.beginningOfLast12Months()^state=requested");
+
+**Executing the Query:**
+grAppr.query();
+
+**Iterating Through the Results:**
+while(grAppr.next()){
+
+**Updating the State:**
+grAppr.setValue('state', 'rejected');
+grAppr.update();


### PR DESCRIPTION
The overall purpose of this script is to identify and reject approval requests that are older than one year and are still in the "requested" state. This helps in cleaning up old approvals that may no longer be relevant.