### PR TITLE
Find Groups without Group Members

### DIFF
--- a/Background Scripts/Find Groups Without Members/Get Groups with no Members.js
+++ b/Background Scripts/Find Groups Without Members/Get Groups with no Members.js
@@ -1,0 +1,17 @@
+var myGroups = [];
+var grGroup = new GlideRecord("sys_user_group");
+grGroup.addActiveQuery();
+grGroup.query();
+while (grGroup.next()) {
+var gaGroupMember = new GlideAggregate("sys_user_grmember");
+gaGroupMember.addQuery("group",grGroup.sys_id.toString());
+gaGroupMember.addAggregate('COUNT');
+gaGroupMember.query();
+var gm = 0;
+if (gaGroupMember.next()) {
+gm = gaGroupMember.getAggregate('COUNT');
+if (gm == 0) 
+      myGroups.push(grGroup.name.toString());
+}
+}
+gs.print(myGroups);

--- a/Background Scripts/Find Groups Without Members/readme.md
+++ b/Background Scripts/Find Groups Without Members/readme.md
@@ -1,0 +1,31 @@
+**Initialize an Array:**
+var myGroups = [];
+
+**Create a GlideRecord Object for User Groups:**
+var grGroup = new GlideRecord("sys_user_group");
+
+**Add a Query for Active Groups:**
+grGroup.addActiveQuery();
+
+**Execute the Query:**
+grGroup.query();
+
+**Iterate Through Active Groups:**
+while (grGroup.next()) {
+
+**Count Group Members:**
+var gaGroupMember = new GlideAggregate("sys_user_grmember");
+gaGroupMember.addQuery("group", grGroup.sys_id.toString());
+gaGroupMember.addAggregate('COUNT');
+gaGroupMember.query();
+
+**Check Member Count:**
+var gm = 0;
+if (gaGroupMember.next()) {
+    gm = gaGroupMember.getAggregate('COUNT');
+    if (gm == 0) 
+        myGroups.push(grGroup.name.toString());
+}
+
+**Print the Results:**
+gs.print(myGroups);


### PR DESCRIPTION
The purpose of this script is to identify and list all active user groups that do not have any members. This can be useful for maintaining user group data, identifying orphaned groups, or cleaning up unnecessary entries.