### PR TITLE
Remove Choice Options Client Script

### DIFF
--- a/Client Scripts/Remove Option from Choice List/Remove Options from Choice List.js
+++ b/Client Scripts/Remove Option from Choice List/Remove Options from Choice List.js
@@ -1,0 +1,9 @@
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+if (isLoading || newValue == '') {
+return;
+}
+if (newValue == 'inquiry') { //Onchange of Category
+g_form.removeOption('impact', '1');
+g_form.removeOption('urgency', '1');
+}
+}

--- a/Client Scripts/Remove Option from Choice List/readme.md
+++ b/Client Scripts/Remove Option from Choice List/readme.md
@@ -1,0 +1,6 @@
+**Purpose:**
+This onChange function automatically reacts when the "Category" field is changed. If the new category selected is "inquiry," the function removes the options for "Impact" and "Urgency" that have a value of 1.
+Whenever a user selects a new category, the script checks if it’s set to "inquiry." If so, it removes the specified options for "Impact" and "Urgency".
+**How to Use This Function**
+You can use this Onchange client script on any form and maanage your field choice options.
+


### PR DESCRIPTION
Whenever a user selects a new category, the script checks if it’s set to "inquiry." If so, it removes the specified options for "Impact" and "Urgency".