### PR TITLE
Fix GlideAggregate Query and Data Retrieval for Incident Statistics

### DIFF
--- a/GlideAggregate/Incident Analysis and Resolution Calculation using Glideaggregate/Incident_analysis_Resolution_Calculation_GlideAggregate.js
+++ b/GlideAggregate/Incident Analysis and Resolution Calculation using Glideaggregate/Incident_analysis_Resolution_Calculation_GlideAggregate.js
@@ -5,8 +5,8 @@ ga.addAggregate('COUNT', 'number');
 ga.addAggregate('AVG', 'time_to_close');
 ga.query();
 while (ga.next()) {
-  var assigned_to = ga.get('assigned_to');
-  var count = ga.get('result');
-  var avgTimeToClose = ga.get('result.avg_time_to_close');
+  var assigned_to = ga.getDisplayValue('assigned_to');
+  var count = ga.getAggregate('COUNT', 'number');
+  var avgTimeToClose = ga.getAggregate('AVG', 'time_to_close');
   gs.info('Assigned to: ' + assigned_to + ', Incident Count: ' + count + ', Average Time to Close: ' + avgTimeToClose);
 }


### PR DESCRIPTION
### Summary: Update Incident_analysis_Resolution_Calculation_GlideAggregate.js
This update fixes the GlideAggregate query for fetching open incident statistics. Previously, the method used to retrieve the 'assigned_to' field and aggregate values was incorrect, causing issues in data retrieval and display. This commit ensures the following:

- `assigned_to` is retrieved using `getDisplayValue()` instead of `get()`, ensuring proper display of user names.
- Correctly retrieves aggregate data using `getAggregate()` for both 'COUNT' and 'AVG' operations to calculate the number of open incidents and average time to close.
- Provides accurate and meaningful output for each assigned user.

### Changes:
- Replaced `ga.get('assigned_to')` with `ga.getDisplayValue('assigned_to')` to get the user display name.
- Corrected `ga.get('result')` and `ga.get('result.avg_time_to_close')` to `ga.getAggregate('COUNT', 'number')` and `ga.getAggregate('AVG', 'time_to_close')` respectively.

### Impact:
This fix improves the accuracy of the reported incident statistics and ensures the correct data is displayed in the logs for better analysis of incident assignment and closure performance.