### PR TITLE
Set price field to accept a single currency

### DIFF
--- a/Client-Side Components/Client Scripts/Price field restriction to one currency/README.md
+++ b/Client-Side Components/Client Scripts/Price field restriction to one currency/README.md
@@ -1,0 +1,13 @@
+
+# Client Script - Set Price type field to only one currency
+
+In a multi currecny enabled servicenow environment, if you have a requirement to enable only one currency choice for a particular table and field of type Price.
+
+## Usage
+
+- Create a new client script
+- Set the type to OnLoad.
+- Copy the script to your client script.
+- Update the <price_field> in the client script to 'Your field name'
+- Add your currency code and symbol in place of USD & $
+- Save

--- a/Client-Side Components/Client Scripts/Price field restriction to one currency/price_field_restriction_to_one_currency.js
+++ b/Client-Side Components/Client Scripts/Price field restriction to one currency/price_field_restriction_to_one_currency.js
@@ -1,0 +1,10 @@
+function onLoad(){
+    // Remove all currency options
+    g_form.clearOptions('<price_field>.currency_type');
+
+    // Add only one currency option (e.g., USD)
+    g_form.addOption('<price_field>.currency_type', 'USD', '$');
+
+    // Set the currency field to the only available option
+    g_form.setValue('<price_field>.currency_type', 'USD');
+}


### PR DESCRIPTION
# Client Script - Set Price type field to only one currency

In a multi currecny enabled servicenow environment, if you have a requirement to enable only one currency choice for a particular table and field of type Price.

## Usage

- Create a new client script
- Set the type to OnLoad.
- Copy the script to your client script.
- Update the <price_field> in the client script to 'Your field name'
- Add your currency code and symbol in place of USD & $
- Save