### PR TITLE
CMDB/IRE - CI deduplication task generator

### DIFF
--- a/Specialized Areas/CMDB/CMDB CI Deduplication Task Generator/CI Deduplication Tasks Generation.js
+++ b/Specialized Areas/CMDB/CMDB CI Deduplication Task Generator/CI Deduplication Tasks Generation.js
@@ -1,0 +1,74 @@
+/**
+ * This script re-checks all duplicate hardware CIs by serial number and creates
+ * a de-duplication task for any group that does not already have an open task.
+ * It leverages the global.CMDBDuplicateTaskUtils Script Include.
+ */
+
+(function() {
+    
+	var ciTable = 'cmdb_ci_hardware'; //Change to any CI table of your choosing
+
+	var groupsFound = 0;
+    var tasksCreated = 0;
+    var groupsSkipped = 0;
+	
+    
+    var taskUtil = new global.CMDBDuplicateTaskUtils();
+
+    // Find all serial numbers that have duplicates using GlideAggregate.
+    var ga = new GlideAggregate(ciTable);
+    ga.addNotNullQuery('serial_number');
+    ga.addQuery('serial_number', '!=', '');
+    ga.addAggregate('COUNT', 'serial_number');
+    ga.groupBy('serial_number');
+    ga.addHaving('COUNT', '>', 1);
+    ga.query();
+
+    gs.info('Starting check for duplicate CIs by serial number...');
+
+    while (ga.next()) {
+        groupsFound++;
+        var serialNumber = ga.getValue('serial_number');
+        var sysIdArray = [];
+        var taskExists = false;
+
+        // For each duplicate serial number, get all associated CI sys_ids.
+        var ciGr = new GlideRecord('cmdb_ci_hardware');
+        ciGr.addQuery('serial_number', serialNumber);
+        ciGr.query();
+        while (ciGr.next()) {
+            sysIdArray.push(ciGr.getUniqueValue());
+        }
+
+        // Check if ANY of the CIs in the group are already in an open task.
+        for (var i = 0; i < sysIdArray.length; i++) {
+            if (!taskUtil.hasNoOpenDuplicateTasks(sysIdArray[i])) {
+                taskExists = true;
+                break; // Found an open task, no need to check the others.
+            }
+        }
+
+        // If no open task exists for this group, create one.
+        if (taskExists) {
+            groupsSkipped++;
+            gs.info('--> Skipping Serial Number "' + serialNumber + '". It is already part of an open task.');
+        } else {
+            var sysIdString = sysIdArray.join(',');
+            var newTaskId = taskUtil.createDuplicateTask(sysIdString);
+            if (newTaskId) {
+                tasksCreated++;
+                gs.info('==> Successfully created task ' + newTaskId + ' for Serial Number "' + serialNumber + '".');
+            } else {
+                gs.error('==> FAILED to create task for Serial Number "' + serialNumber + '".');
+            }
+        }
+    }
+
+    // --- Final Summary ---
+    gs.info('--- Re-check Complete ---');
+    gs.info('Total Duplicate Groups Found: ' + groupsFound);
+    gs.info('New Remediation Tasks Created: ' + tasksCreated);
+    gs.info('Groups Skipped (Already in an open task): ' + groupsSkipped);
+    gs.info('--------------------------');
+
+})();

--- a/Specialized Areas/CMDB/CMDB CI Deduplication Task Generator/README.md
+++ b/Specialized Areas/CMDB/CMDB CI Deduplication Task Generator/README.md
@@ -1,0 +1,47 @@
+# CI Deduplication Task Generator
+
+This script rechecks the cmdb_ci_hardware table for duplicates by serial number and creates a De-Duplication Task if needed (for records that didn't run through the IRE).
+
+### How It Works
+
+1. Finds all serial numbers that are used on more than one hardware CI.
+
+2. For each group of duplicates, it checks if any of the CIs are already part of an open de-duplication task.
+
+3. If no open task exists, it creates a new one linking all CIs in the group.
+
+4. Logs a summary of actions taken (tasks created, groups skipped).
+
+### Dependencies
+
+This script requires the `global.CMDBDuplicateTaskUtils` Script Include to be active in your instance.
+
+### Configuration & Use
+
+This script is meant to be run as a **Scheduled Job** or as a **Background Script**.
+
+Before you run it, you must set the target table.
+
+```
+// Change this line in the script!
+var ciTable = "cmdb_ci_hardware" 
+
+
+```
+
+Change `"cmdb_ci_hardware"` to the table you want to run the script against.
+
+### Example Log Output
+
+```
+Starting check for duplicate CIs by serial number...
+==> Successfully created task RITM0010123 for Serial Number "VMW-50-81-7A-C9-23-44".
+--> Skipping Serial Number "SGH814X025". It is already part of an open task.
+--- Re-check Complete ---
+Total Duplicate Groups Found: 2
+New Remediation Tasks Created: 1
+Groups Skipped (Already in an open task): 1
+--------------------------
+
+
+```


### PR DESCRIPTION
The script rechecks the cmdb_ci_hardware table (or any configured CI table) for records that share the same serial number. This is for identifying duplicates that may not have been processed by IRE or imports that did not run through IRE.