### PR TITLE
Add Custom Test Step Configuration Script to Fetch Number & Short Description

### DIFF
--- a/Specialized Areas/ATF Steps/Custom Test Step/Get Number & Short Description.js
+++ b/Specialized Areas/ATF Steps/Custom Test Step/Get Number & Short Description.js
@@ -1,0 +1,18 @@
+(function executeStep(inputs, outputs, stepResult, timeout) {
+
+	var recordSysId = inputs.u_sys_id;
+
+    var finance = new GlideRecord("incident");
+    finance.addQuery("sys_id", recordSysId);
+    finance.query();
+    if (finance.next()) {
+        outputs.u_number = finance.getDisplayValue("number");
+		outputs.u_short_description= finance.getDisplayValue("short_description");
+        stepResult.setOutputMessage('Found the record');
+        stepResult.setSuccess();
+    } else {
+        stepResult.setOutputMessage('Record not found');
+        stepResult.setFailed();
+    }
+
+}(inputs, outputs, stepResult, timeout));

--- a/Specialized Areas/ATF Steps/Custom Test Step/Readme.md
+++ b/Specialized Areas/ATF Steps/Custom Test Step/Readme.md
@@ -1,0 +1,3 @@
+Above custom test step configuration script will help to get the "Number" & "Short Description" based on the sys_id of the incident. Let's say while performing any server dependent steps on incident table this custom step configuration script can be very usefullt to retrieve the details, not only about incident or number, short_description. Anybody can utilize this script to create custom step configuration script on different usecases o scenario.
+
+Note: You need to define the inputs & outputs for this, in my case I have defined the 'sys_id' as an input and "Number" & "Short Description" as an output to store the values and use it anywhere. Also to make sure you define the "stepResult.setOutputMessage("Successfull")" and "stepResult.setOutputMessage("Unsuccessfull")"


### PR DESCRIPTION
Above custom test step configuration script will help to get the "Number" & "Short Description" based on the sys_id of the incident. Let's say while performing any server dependent steps on incident table this custom step configuration script can be very usefullt to retrieve the details, not only about incident or number, short_description. Anybody can utilize this script to create custom step configuration script on different usecases o scenario.

Note: You need to define the inputs & outputs for this, in my case I have defined the 'sys_id' as an input and "Number" & "Short Description" as an output to store the values and use it anywhere. Also to make sure you define the "stepResult.setOutputMessage("Successfull")" and "stepResult.setOutputMessage("Unsuccessfull")"