### PR TITLE
Create get_ancestor_tasks.js

### DIFF
--- a/get_ancestor_tasks.js
+++ b/get_ancestor_tasks.js
@@ -1,0 +1,36 @@
+/**
+ * getAncestorTasks — Return an array of parent task records up the chain.
+ * @param {String} tableName — the name of the task table (e.g. “incident”)
+ * @param {String} sysId — sys_id of the starting record
+ * @param {Number} maxDepth — optional maximum depth to prevent infinite loops
+ * @returns {GlideRecord[]} — array of ancestor GlideRecord objects, ordered from immediate parent up to root
+ */
+function getAncestorTasks(tableName, sysId, maxDepth = 10) {
+    var ancestors = [];
+    var seen = {};
+    var depth = 0;
+
+    var gr = new GlideRecord(tableName);
+    if (!gr.get(sysId)) {
+        return ancestors;  // no starting record
+    }
+
+    while (gr.parent && gr.parent.toString() && depth < maxDepth) {
+        var parentId = gr.parent.toString();
+        if (seen[parentId]) {
+            gs.warn("getAncestorTasks: detected cycle at " + parentId);
+            break;
+        }
+        seen[parentId] = true;
+
+        var parentGr = new GlideRecord(tableName);
+        if (!parentGr.get(parentId)) {
+            gs.warn("getAncestorTasks: parent record not found: " + parentId);
+            break;
+        }
+        ancestors.push(parentGr);
+        gr = parentGr;
+        depth++;
+    }
+    return ancestors;
+}


### PR DESCRIPTION
📌 Description

This PR adds a new snippet getAncestorTasks under the Utilities/ folder.
The function retrieves all parent tasks in a hierarchy chain (e.g. incidents, problems, changes) by traversing the parent field until the root task is reached.

🛠️ Details

Works with any task-like table that has a parent field.

Returns an array of ancestor GlideRecords, ordered from immediate parent up to root.

Includes cycle detection and depth limit (default 10) to avoid infinite loops.

Useful for rollups, reporting, and escalation logic.

✅ Example Usage
var chain = getAncestorTasks('incident', current.sys_id, 20);
for (var i = 0; i < chain.length; i++) {
    gs.info("Ancestor #" + (i+1) + ": " + chain[i].getDisplayValue('number'));
}

🔗 Why It’s Useful

This snippet provides a reusable utility for scenarios where developers need to:

Display full parent task hierarchies.

Aggregate data across parent chains.

Implement escalations or rollup calculations.