### PR TITLE
Apply field style on List type fields - Highlight Reviewers if anyone is inactive

### DIFF
--- a/Server-Side Components/Server Side/MarkInactiveUsersonList/README.md
+++ b/Server-Side Components/Server Side/MarkInactiveUsersonList/README.md
@@ -1,0 +1,6 @@
+There is a list type field named 'Reviewers' on Policy records.
+On the list view of Policies, we want to highlight with field styles, where any of the user listed under Reviewers is inactive.
+In the screenshot attached below, Daniel Zill is inactive user, and if he is present in Reviewers, the respective column value is applied with defined field styles.
+<img width="809" height="370" alt="image" src="https://github.com/user-attachments/assets/b483207e-f3ba-4db7-a717-d392694eaf50" />
+<img width="433" height="107" alt="image" src="https://github.com/user-attachments/assets/5129038f-d210-40f4-bcd8-1727d791edca" />
+

--- a/Server-Side Components/Server Side/MarkInactiveUsersonList/fieldStyleforListfields.js
+++ b/Server-Side Components/Server Side/MarkInactiveUsersonList/fieldStyleforListfields.js
@@ -1,0 +1,18 @@
+//The below code followed by "javascript:", inside 'Value' field for the List type Reviewers field's Style record will do the condition check.
+
+var answer = false; 
+var arr=[]; 
+arr = current.reviewers.split(','); 
+for(i=0; i<arr.length; i++){
+  var gr = new GlideRecord('sys_user');
+  gr.addQuery('sys_id',arr[i]);
+  gr.query(); 
+  if(gr.next()){ 
+    if(gr.active == false){ 
+      answer = true;
+    }
+  }
+} 
+answer;
+
+//The Style field then must be populated with the style we want to apply. I have applied "background-color: blue;" "text-decoration:line-through;"


### PR DESCRIPTION
# PR Description: If any user has become inactive, we should be able to highlight such records where they are present among many listed users (Reviewers, Approvers etc.). We can apply Field styles and check using conditions to mark those records.


# Pull Request Checklist

## Overview
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
