### PR TITLE
Business Rule: Add Work Notes for Related Change Requests by CI

### DIFF
--- a/Server-Side Components/Business Rules/Add work notes for relevant Change Requests for Incident/README.md
+++ b/Server-Side Components/Business Rules/Add work notes for relevant Change Requests for Incident/README.md
@@ -1,0 +1,5 @@
+Adds the Change Request numbers to the work notes of incidents that have the same CI.
+Operates on the Incident table as a Before Business Rule.
+
+Excludes CRs that are closed and cancelled.
+Helps agents to quickly identify related changes during incident triage.

--- a/Server-Side Components/Business Rules/Add work notes for relevant Change Requests for Incident/script.js
+++ b/Server-Side Components/Business Rules/Add work notes for relevant Change Requests for Incident/script.js
@@ -1,0 +1,24 @@
+(function executeRule(current, previous /*null when async*/) {
+
+	if(current.cmdb_ci){
+		var ci = current.cmdb_ci.getValue();
+
+		var chng = new GlideRecord('change_request');
+		chng.addQuery('cmdb_ci', ci);
+		chng.addQuery('state', '!=', '3');
+		chng.addQuery('state', '!=', '4');
+		chng.query();
+
+		var work_notes = '';
+
+		while(chng.next()){
+			work_notes += chng.getValue('number') + '\n';
+		}
+
+		if(work_notes){
+			current.work_notes = 'Following change requests are associated with the same CI. You can attach one of them.\n' + work_notes;
+		}
+	
+	}
+
+})(current, previous);


### PR DESCRIPTION
# PR Description: 

This Business Rule automatically adds active Change Request numbers to an Incident's work notes if the Incident shares the same Configuration Item (CI).
It runs before Insert/Update on the Incident table and excludes Closed and Canceled CRs.
This helps service desk agents quickly identify related Change Requests and avoid duplicate efforts.

# Pull Request Checklist

## Overview
- [ ] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My pull request has a descriptive title that accurately reflects the changes
- [ ] I've included only files relevant to the changes described in the PR title and description
- [ ] I've created a new branch in my forked repository for this contribution

## Code Quality
- [ ] My code is relevant to ServiceNow developers
- [ ] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [ ] I've disclosed use of ES2021 features (if applicable)
- [ ] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [ ] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [ ] I've used appropriate sub-categories within the top-level categories
- [ ] Each code snippet has its own folder with a descriptive name

## Documentation
- [ ] I've included a README.md file for each code snippet
- [ ] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [ ] My PR does not include XML exports of ServiceNow records
- [ ] My PR does not contain sensitive information (passwords, API keys, tokens)
- [ ] My PR does not include changes that fall outside the described scope
