### PR TITLE
Fix out-of-order return in ATF step snippet

### DIFF
--- a/Specialized Areas/ATF Steps/Count table records/script.js
+++ b/Specialized Areas/ATF Steps/Count table records/script.js
@@ -3,9 +3,9 @@
   var gr = new GlideAggregate('incident');
   gr.addAggregate('COUNT');
   gr._query();
-  if (gr.next()) {			
-    return gr.getAggregate('COUNT'); // pass the step
+  if (gr.next()) {
     stepResult.setOutputMessage("Successfully Calculated the Count");
+	return gr.getAggregate('COUNT'); // pass the step
   } else { 
     stepResult.setOutputMessage("Failed to Count");
     return false; // fail the step


### PR DESCRIPTION
# PR Description: 

This would cause the output message of the step to not be set correctly in the success case

# Pull Request Checklist

## Overview
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
