### PR TITLE
Fix invalid JS syntax in autonumber fix script

### DIFF
--- a/Specialized Areas/Fix scripts/AutoNumberIssueFix/autonumberingcode.js
+++ b/Specialized Areas/Fix scripts/AutoNumberIssueFix/autonumberingcode.js
@@ -1,6 +1,6 @@
-# Fixscript for autonumbering issues
-# This script will be run in global using scripts Background
-# Update the tableName per requirement
+// Fix script for autonumbering issues
+// This script will be run in global using scripts Background
+// Update the tableName per requirement
 
 var nm = new NumberManager(tableName);
 
@@ -15,8 +15,6 @@ grTableName.orderBy('sys_created_on');
 grTableName.query();
 
 while (grTableName.next()) {
-	
-grTableName.number = 
-nm.getNextObjNumberPadded();
-	
-grTableName.update();
+	grTableName.number = nm.getNextObjNumberPadded();
+	grTableName.update();
+}


### PR DESCRIPTION
# PR Description: 

Previously, the file used invalid JS comment
syntax and was missing a closing bracket on
its while block.

# Pull Request Checklist

## Overview
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
