### PR TITLE
feat: generate slug from text

### DIFF
--- a/Client-Side Components/Client Scripts/Generate Slug from Text/README.md
+++ b/Client-Side Components/Client Scripts/Generate Slug from Text/README.md
@@ -1,0 +1,5 @@
+# ServiceNow JavaScript Helper
+
+## String Helper 
+
+- `toSlug("Hello World!")` → `"hello-world"`

--- a/Client-Side Components/Client Scripts/Generate Slug from Text/slugGenerate.js
+++ b/Client-Side Components/Client Scripts/Generate Slug from Text/slugGenerate.js
@@ -1,0 +1,8 @@
+// Converts string to lowercase, removes symbols, replaces spaces with dashes
+function toSlug(text) {
+	let str = text.toLowerCase();
+	str = str.replace(/[^a-z0-9_\s-]/g, "");
+	str = str.replace(/[\s-]+/g, " ");
+	str = str.replace(/[\s_]/g, "-");
+	return str;
+};


### PR DESCRIPTION
# PR Description: 

### Added Functions
- `toSlug(text)` → Converts string to lowercase slug (e.g., `"Hello World!" → "hello-world"`)

### Why
String manipulation is common in ServiceNow (field values, display names, search filters).  
These helpers reduce repetitive regex/code snippets.

### Example Usage
```javascript
gs.info(toSlug("Hello World!"));       // "hello-world"
```

# Pull Request Checklist

## Overview
- [ ] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My pull request has a descriptive title that accurately reflects the changes
- [ ] I've included only files relevant to the changes described in the PR title and description
- [ ] I've created a new branch in my forked repository for this contribution

## Code Quality
- [ ] My code is relevant to ServiceNow developers
- [ ] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [ ] I've disclosed use of ES2021 features (if applicable)
- [ ] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [ ] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [ ] I've used appropriate sub-categories within the top-level categories
- [ ] Each code snippet has its own folder with a descriptive name

## Documentation
- [ ] I've included a README.md file for each code snippet
- [ ] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [ ] My PR does not include XML exports of ServiceNow records
- [ ] My PR does not contain sensitive information (passwords, API keys, tokens)
- [ ] My PR does not include changes that fall outside the described scope
