### PR TITLE
Convert utc to local time

### DIFF
--- a/Core ServiceNow APIs/GlideDateTime/Convert UTC to Local Time/readme.md
+++ b/Core ServiceNow APIs/GlideDateTime/Convert UTC to Local Time/readme.md
@@ -1,0 +1,7 @@
+## Overview
+This script converts a UTC date/time field in ServiceNow to the **user's local time** using **GlideDateTime**.  
+Useful for notifications, reports, dashboards, or any situation where users need **localized timestamps**.
+
+## Table and Field Example
+- **Table:** `incident`
+- **Field:** `opened_at` (stored in UTC)

--- a/Core ServiceNow APIs/GlideDateTime/Convert UTC to Local Time/script.js
+++ b/Core ServiceNow APIs/GlideDateTime/Convert UTC to Local Time/script.js
@@ -1,0 +1,21 @@
+(function() {
+    var gr = new GlideRecord('incident');
+    gr.addQuery('active', true);
+    gr.orderByDesc('opened_at');
+    gr.setLimit(1); // Example: take the latest active incident
+    gr.query();
+
+    if (gr.next()) {
+        // GlideDateTime object from UTC field
+        var utcDateTime = gr.opened_at;
+
+        // Convert to user's local time zone
+        var localTime = new GlideDateTime(utcDateTime);
+        var displayValue = localTime.getDisplayValue(); // Returns local time in user's timezone
+
+        gs.info('UTC Time: ' + utcDateTime);
+        gs.info('Local Time: ' + displayValue);
+    } else {
+        gs.info('No active incidents found.');
+    }
+})();


### PR DESCRIPTION
# PR Description: In ServiceNow, date/time fields are stored in UTC. To display or process the date in the user’s local time, we can use **GlideDateTime** methods. This is useful in notifications, reports, and UI messages.


# Pull Request Checklist

## Overview
- [ ] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My pull request has a descriptive title that accurately reflects the changes
- [ ] I've included only files relevant to the changes described in the PR title and description
- [ ] I've created a new branch in my forked repository for this contribution

## Code Quality
- [ ] My code is relevant to ServiceNow developers
- [ ] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [ ] I've disclosed use of ES2021 features (if applicable)
- [ ] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [ ] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [ ] I've used appropriate sub-categories within the top-level categories
- [ ] Each code snippet has its own folder with a descriptive name

## Documentation
- [ ] I've included a README.md file for each code snippet
- [ ] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [ ] My PR does not include XML exports of ServiceNow records
- [ ] My PR does not contain sensitive information (passwords, API keys, tokens)
- [ ] My PR does not include changes that fall outside the described scope
