### PR TITLE
Captures the time it took to assign a task

### DIFF
--- a/Server-Side Components/Business Rules/Tracks the time it took to assign a Task/README.md
+++ b/Server-Side Components/Business Rules/Tracks the time it took to assign a Task/README.md
@@ -1,0 +1,7 @@
+This script tracks the time it took to assign a task (like an Incident, Change, etc.) by calculating the difference
+between when the record was created and when it was assigned (assigned_to was set).
+It checks if the assigned_to field has changed and is not empty.
+If it's the first time the record is being assigned (u_assignment_time is empty), it captures the current time.
+It then calculates the time difference between when the record was created and when it was assigned.
+This time difference (in minutes) is stored in a custom field u_time_to_assign.
+The goal is to track how long it took for the record to be assigned after creation

--- a/Server-Side Components/Business Rules/Tracks the time it took to assign a Task/script.js
+++ b/Server-Side Components/Business Rules/Tracks the time it took to assign a Task/script.js
@@ -1,0 +1,32 @@
+(function executeRule(current, previous /*null when async*/) {
+
+    // Only proceed if assigned_to changed AND is not empty/null
+    if (current.assigned_to.changes() && !gs.nil(current.assigned_to)) {
+        
+        gs.info("Assigned_to changed and assigned_to is: " + current.assigned_to);
+
+        // Only set u_assigned_time if empty
+        if (!current.u_assigned_time) {
+            
+            var assignedTime = new GlideDateTime();
+            current.u_assigned_time = assignedTime;
+
+            var createdTime = new GlideDateTime(current.sys_created_on);
+
+            var diffMillis = assignedTime.getNumericValue() - createdTime.getNumericValue();
+            var diffMinutes = diffMillis / (1000 * 60);
+
+            gs.info("Time difference in minutes: " + diffMinutes);
+
+            // Assuming u_time_to_assign is a string field
+            current.u_time_to_assign = diffMinutes.toFixed(2) + " minutes";
+            
+            gs.info("Set u_time_to_assign to: " + current.u_time_to_assign);
+        } else {
+            gs.info("u_assigned_time already set: " + current.u_assigned_time);
+        }
+    } else {
+        gs.info("Assigned_to not changed or is empty.");
+    }
+
+})(current, previous);


### PR DESCRIPTION
This Business Rule in ServiceNow is used to track how long it takes to assign a record after it is created, typically on a task table like Incident, Change, or a custom table.

If this is the first time the record is being assigned (i.e., u_assigned_time is empty):
Sets the field u_assigned_time to the current time.
Calculates how many minutes passed since the record was created (sys_created_on).
Stores that difference in a custom field u_time_to_assign (as a string like "15.33 minutes").
If the record was already assigned before (u_assigned_time is not empty), it just logs that and does nothing.