### PR TITLE
Create De-duplicationTasksButton

### DIFF
--- a/Specialized Areas/ITOM/De-duplicationTasksButton
+++ b/Specialized Areas/ITOM/De-duplicationTasksButton
@@ -1,0 +1,50 @@
+//UI Action for Create De-duplicate Tasks 
+//Onclick showConfirmationDialog
+
+function showConfirmationDialog() {
+var entries = g_list.getChecked();
+var sysIDs = entries.split(',');
+
+var con1 = confirm('Total number of Selected CIs ' + sysIDs.length + '. Click OK to create De-duplicate task');
+
+if (con1) {
+alert(sysIDs);
+var ga = new GlideAjax('createDuplicateCITask');
+ga.addParam('sysparm_name', 'createDeDupTask');
+ga.addParam('sysparm_entry_ids', entries);
+ga.getXML(getDupTasks);
+}
+
+function getDupTasks(response) {
+
+var answer = response.responseXML.documentElement.getAttribute("answer");
+if (answer == null) {
+alert('Failed to create Remediate Duplicate Task. Selected CIs are already part of an open Remediate Duplicate Task');
+} else {
+var url1 = 'reconcile_duplicate_task.do?sys_id=' + answer;
+var con = confirm('The De-duplicate task is created. Click OK to redirect to De-duplicate task record');
+if (con) {
+location.href = url1;
+}
+}
+}
+}
+
+//Script Include
+
+var createDuplicateCITask = Class.create();
+createDuplicateCITask.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+createDeDupTask: function() {
+var entries = this.getParameter('sysparm_entry_ids');
+
+var dupTaskUtil = new CMDBDuplicateTaskUtils();
+var deDupTaskID = dupTaskUtil.createDuplicateTask(entries);
+
+return deDupTaskID;
+
+},
+
+type: 'createDuplicateCITask'
+});
+
+ 


### PR DESCRIPTION
Creation of De-duplicate Tasks manually found duplicate records with UI Action.

# PR Description: 
This Button will be used to create manually found duplicate records from the list view, if we enable button on the "Additional Actions on Selected Rows".

# Pull Request Checklist

## Overview
- [ ] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My pull request has a descriptive title that accurately reflects the changes
- [ ] I've included only files relevant to the changes described in the PR title and description
- [ ] I've created a new branch in my forked repository for this contribution

## Code Quality
- [ ] My code is relevant to ServiceNow developers
- [ ] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [ ] I've disclosed use of ES2021 features (if applicable)
- [ ] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [ ] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [ ] I've used appropriate sub-categories within the top-level categories
- [ ] Each code snippet has its own folder with a descriptive name

## Documentation
- [ ] I've included a README.md file for each code snippet
- [ ] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [ ] My PR does not include XML exports of ServiceNow records
- [ ] My PR does not contain sensitive information (passwords, API keys, tokens)
- [ ] My PR does not include changes that fall outside the described scope
