### PR TITLE
Create DepartmentFilter.js

### DIFF
--- a/DepartmentFilter.js
+++ b/DepartmentFilter.js
@@ -1,0 +1,19 @@
+var getSameDeptUsers = Class.create();
+getSameDeptUsers.prototype = {
+    initialize: function() {},
+    getSameDept: function() {
+        var user = gs.getUser().getDepartmentID();
+        var d = new GlideRecord('sys_user');
+        d.addQuery('department', user);
+        d.query();
+
+        var str = "";
+        while (d.next()) {
+            str = str + "," + d.sys_id;
+        }
+        return 'sys_idIN' + str;
+
+    },
+
+    type: 'getSameDeptUsers'
+};


### PR DESCRIPTION
This Reference Qualifier is configured on the Caller field to display only those users whose Department matches the currently logged-in user’s department.

We are simply checking the condition at the script level (this can also be configured at the condition/filter level). This helps ensure that users can only select callers from their own department.