### PR TITLE
Client Script - Incident to Problem Fields Mapping

### DIFF
--- a/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/IncidentDetails.js
+++ b/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/IncidentDetails.js
@@ -1,0 +1,22 @@
+//Script include to get the values of incident record fields
+var IncidentDetails = Class.create();
+IncidentDetails.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+
+	getIncidentDetails: function() {
+        var inc = this.getParameter('sysparm_incidentSysId');
+        var result = {};
+
+        var gr = new GlideRecord('incident');
+        if (gr.get(inc)) {
+            result.cmdb_ci = gr.cmdb_ci.toString();
+            result.priority = gr.priority.toString();
+            result.assignment_group = gr.assignment_group.toString();
+      			result.short_description = gr.short_description.toString();
+      			result.description = gr.description.toString();
+        }
+
+        return JSON.stringify(result);
+    },
+
+    type: 'IncidentDetails'
+});

--- a/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/IncidentToProblemMapping.js
+++ b/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/IncidentToProblemMapping.js
@@ -1,0 +1,21 @@
+//Client script to map the fields in problem
+function onChange(control, oldValue, newValue, isLoading, isTemplate) {
+	
+   if (newValue === '') {
+	return;
+   }
+
+   var ga = new GlideAjax('IncidentDetails');
+    ga.addParam('sysparm_name', 'getIncidentDetails');
+    ga.addParam('sysparm_incidentSysId', newValue);
+    ga.getXMLAnswer(function(response) {
+        var result = JSON.parse(response);
+
+        g_form.setValue('cmdb_ci', result.cmdb_ci);
+        g_form.setValue('priority', result.priority);
+        g_form.setValue('assignment_group', result.assignment_group);
+		g_form.setValue('short_description', result.short_description);
+		g_form.setValue('description', result.description);
+    });   
+   
+}

--- a/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/README.md
+++ b/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/README.md
@@ -1,0 +1,23 @@
+**Maps Incident Fields to Child Problem**
+
+**Description:**
+This client script automatically maps key field values from a parent Incident record to a Problem record when the user creates a new Problem and selects an Incident record in the Parent reference field.
+
+**Client Script:**
+Name: IncidentToProblemMapping
+Table: Problem [problem]
+Type: onChange
+Field name: Parent
+
+**Script Include:**
+Name: IncidentDetails
+Glide AJAX enabled: checked
+
+**Implementation:**
+Place this script on the Problem table with the condition that it triggers on change of the Parent field. When the selected parent record is from the Incident table, it fetches field values from the Incident using GlideAjax and sets them on the Problem form.
+Fields Mapped:
+•	Configuration Item
+•	Priority
+•	Assignment Group
+•	Short Description
+•	Description

--- a/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/README.md
+++ b/Client-Side Components/Client Scripts/Incident to Problem Field Mapper/README.md
@@ -15,6 +15,7 @@ Glide AJAX enabled: checked
 
 **Implementation:**
 Place this script on the Problem table with the condition that it triggers on change of the Parent field. When the selected parent record is from the Incident table, it fetches field values from the Incident using GlideAjax and sets them on the Problem form.
+
 Fields Mapped:
 •	Configuration Item
 •	Priority


### PR DESCRIPTION
Client Script - Maps Incident Fields to Child Problem
Description:
This client script automatically maps key field values from a parent Incident record to a Problem record when the user creates a new Problem and selects an Incident record in the Parent reference field.

Client Script:
Name: IncidentToProblemMapping
Table: Problem [problem]
Type: onChange
Field name: Parent

Script Include:
Name: IncidentDetails
Glide AJAX enabled: checked

Implementation:
Place this script on the Problem table with the condition that it triggers on change of the Parent field. When the selected parent record is from the Incident table, it fetches field values from the Incident using GlideAjax and sets them on the Problem form.
Fields Mapped:
•	Configuration Item
•	Priority
•	Assignment Group
•	Short Description
•	Description
