### PR TITLE
MRVS Reference Qualifier Dependent on First Row Variable

### DIFF
--- a/Client-Side Components/Catalog Client Script/MRVS dependent ref qual 1st row/README.md
+++ b/Client-Side Components/Catalog Client Script/MRVS dependent ref qual 1st row/README.md
@@ -1,0 +1,6 @@
+This Catalog Client Script is used with a Script Include and reference qualifier similar to
+javascript: 'disable=false' + session.getClientData('selected_dept');
+
+The scenario is a MRVS with a reference variable to the customer account table.  When an (active) account is selected in the first row, subsequent rows should only be able to select active accounts in the same department as the first account.
+
+This Catalog Client Script will pass the first selected account (if there is one) to a Script Include each time a MRVS row is added or edited.

--- a/Client-Side Components/Catalog Client Script/MRVS dependent ref qual 1st row/onLoad mrvs
+++ b/Client-Side Components/Catalog Client Script/MRVS dependent ref qual 1st row/onLoad mrvs
@@ -1,0 +1,17 @@
+function onLoad() {
+    //applies to MRVS, not Catalog Item. This will pass the first selected account (if there is one) to a Script Include each time a MRVS row is added or edited
+    var mrvs = g_service_catalog.parent.getValue('my_mrvs'); //MRVS internal name
+	var acct = '';
+	if (mrvs.length > 2) { //MRVS is not empty
+		var obj = JSON.parse(mrvs);
+       	acct = obj[0].account_mrvs;
+	}
+	var ga = new GlideAjax('AccountUtils');
+    ga.addParam('sysparm_name', 'setSessionData');
+    ga.addParam('sysparm_account', acct);
+    ga.getXMLAnswer(getResponse);
+}
+
+function getResponse(response) { 
+    //do nothing 
+}

--- a/Server-Side Components/Script Includes/MRVS dependent ref qual 1st row/README.md
+++ b/Server-Side Components/Script Includes/MRVS dependent ref qual 1st row/README.md
@@ -1,0 +1,6 @@
+This Script Include is used with a Catalog Client Script and reference qualifier similar to
+javascript: 'disable=false' + session.getClientData('selected_dept');
+
+The scenario is a MRVS with a reference variable to the customer account table.  When an (active) account is selected in the first row, subsequent rows should only be able to select active accounts in the same department as the first account.
+
+This Script Include will populate the department name from the account in the session data for the reference qualifier to use.

--- a/Server-Side Components/Script Includes/MRVS dependent ref qual 1st row/set session data
+++ b/Server-Side Components/Script Includes/MRVS dependent ref qual 1st row/set session data
@@ -1,0 +1,19 @@
+var AccountUtils = Class.create();
+AccountUtils.prototype = Object.extendsObject(AbstractAjaxProcessor, {
+
+    //Populate the department name from the account in the session data for the reference qualifier to use:
+    
+    setSessionData: function() {
+        var acct = this.getParameter('sysparm_account');
+		    var dept = '';
+		    var acctGR = new GlideRecord('customer_account'); //reference table for Account variable
+		    if (acctGR.get(acct)) {
+			      dept = '^dept_name=' + acctGR.dept_name; //department field name on account table
+		    }
+		
+		    var session = gs.getSession().putClientData('selected_dept', dept);
+        return;
+    },
+
+    type: 'AccountUtils'
+});


### PR DESCRIPTION
# PR Description: 
The use case is a MRVS with a reference variable (to the customer account table in this case).  When an (active) account is selected in the first row, subsequent rows should only be able to select active accounts in the same department as the first account.

# Pull Request Checklist

## Overview
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
