### PR TITLE
Fetch field value passed as query parameter from URL and set the value on the field

### DIFF
--- a/Client-Side Components/Catalog Client Script/Auto-populate field from URL/README.md
+++ b/Client-Side Components/Catalog Client Script/Auto-populate field from URL/README.md
@@ -1,0 +1,17 @@
+This piece of code is designed for an usecase where you might want to populate a field value that you're passing as a query in the URL which redirects to a catalog item.
+In this case, a custom field 'u_date' is chosen as an example to be shown:
+
+1. You open a catalog item record via a URL that carries a date in the query string.
+Example:
+https://your-instance.service-now.com/your_form.do?sysparm_u_date=2025-10-31
+-(This URL includes a parameter named sysparm_u_date with the value 2025-10-31.)
+
+
+2. The catalog client script reads the page URL and extracts that specific parameter which returns the value "2025-10-31".
+
+3. If the parameter is present, the script populates the form field.
+Calling g_form.setValue('u_date', '2025-10-31') sets the date field on the form to 31 October 2025.
+
+
+Result:
+The date field in the form is prefilled from the URL

--- a/Client-Side Components/Catalog Client Script/Auto-populate field from URL/popdatefromurl.js
+++ b/Client-Side Components/Catalog Client Script/Auto-populate field from URL/popdatefromurl.js
@@ -1,0 +1,8 @@
+//Logic to fetch the u_date field value passed in the url and setting it in the actual field.
+
+
+var fetchUrl = top.location.href; //get the URL
+
+var setDate = new URLSearchParams(gUrl).get("sysparm_u_date");  //fetch the value of date from the query parameter
+
+g_form.setValue('u_date', setDate);   //set the value to the actual field


### PR DESCRIPTION
This piece of code is designed for an usecase where you might want to populate a field value that you're passing as a query in the URL which redirects to a catalog item.
In this case, a custom field 'u_date' is chosen as an example to be shown:

1. You open a catalog item record via a URL that carries a date in the query string.
Example:
https://your-instance.service-now.com/your_form.do?sysparm_u_date=2025-10-31
-(This URL includes a parameter named sysparm_u_date with the value 2025-10-31.)


2. The catalog client script reads the page URL and extracts that specific parameter which returns the value "2025-10-31".

3. If the parameter is present, the script populates the form field.
Calling g_form.setValue('u_date', '2025-10-31') sets the date field on the form to 31 October 2025.


Result:
The date field in the form is prefilled from the URL