### PR TITLE
Snippets2025

### DIFF
--- a/Integration/Mail Scripts/cc all group members/README.md
+++ b/Integration/Mail Scripts/cc all group members/README.md
@@ -1,7 +1,7 @@
 This mail script can be used to CC all members of a group in the current record context. 
 
 Use case: 
-CC all members of the assignment group for the current record.
+CC all active members of the assignment group for the current record.
 
 Solution: 
 Create the mail script as mentioned in cc all group members.js file and then call the mail script in you email notification using ${mail_script: your mail script name} in the notification body

--- a/Integration/Mail Scripts/cc all group members/cc all group members.js
+++ b/Integration/Mail Scripts/cc all group members/cc all group members.js
@@ -8,6 +8,7 @@
     // Add your code here
     var grp = new GlideRecord('sys_user_grmember');  //Query to the group member table
     grp.addQuery("group", current.assignment_group);   //add a filter to query based on the current record's assignment group
+    grp.addQuery("user.active", true);   // all active users
     grp.query();
     while (grp.next()) {
        email.addAddress('cc', grp.user.email, grp.user.name); //Passing email as name and 2nd and 3rd parameter


### PR DESCRIPTION
Optimised query added to "[cc all group members.js]" Email Script under Integration > Mail Scripts.
It will now pull all active users of the group
*********************************************************************************************************
This mail script can be used to CC all members of a group in the current record context. 

Use case: 
CC all members of the assignment group for the current record.
CC all active members of the assignment group for the current record.

Solution: 
Create the mail script as mentioned in cc all group members.js file and then call the mail script in you email notification using ${mail_script: your mail script name} in the notification body
Copilot menu
