### PR TITLE
Return date validation for a catalog item using onChange script

### DIFF
--- a/Client-Side Components/Catalog Client Script/Return Date Validation/README.md
+++ b/Client-Side Components/Catalog Client Script/Return Date Validation/README.md
@@ -1,0 +1,15 @@
+This piece of code runs in an OnChange catalog client script for the field 'u_return_date' and validates the return date(u_return_date) in a ServiceNow Catalog item form to ensure:
+
+1. A start date(u_start_date) is entered before setting a return date(u_return_date).
+2. The return date is within 6 months after the start date.
+3. Return date is not the start date or before that.
+
+Let’s say with an example:
+
+  u_start_date = 2025-10-01
+  You enter u_return_date = 2026-04-15
+  
+  Steps:
+  a)Difference = 196 days → More than 180 days
+  b)Result: u_return_date is cleared and error shown: “Select Return Date within 6 months from Start Date”
+

--- a/Client-Side Components/Catalog Client Script/Return Date Validation/validateReturndate.js
+++ b/Client-Side Components/Catalog Client Script/Return Date Validation/validateReturndate.js
@@ -1,0 +1,23 @@
+function onChange(control, oldValue, newValue, isLoading) {
+    if (isLoading || newValue == '') {
+        return;
+    }
+    var u_start_date = g_form.getValue('u_start_date');  //start date validation to check to see whether filled or not
+    if (!u_start_date) {
+        g_form.clearValue('u_return_date');
+		    g_form.showFieldMsg('u_return_date', 'Please enter start date', 'error');
+    } else {
+    		var startTime = getDateFromFormat(u_start_date, g_user_date_format);   //converting to js date object
+    		var returnTime = getDateFromFormat(newValue, g_user_date_format);
+    		var selectedStartDate = new Date(startTime);
+    		var returnDate = new Date(returnTime);
+    		var returnDateDifference = (returnDate - selectedStartDate) / 86400000; //converting the diff between the dates to days by dividing by 86400000 
+    		if (returnDateDifference > 180) {
+      			g_form.clearValue('u_return_date');
+      			g_form.showFieldMsg('u_return_date', 'Select Return Date within 6 months from Start Date', 'error');
+    		} else if (returnDateDifference < 1) {
+      			g_form.clearValue('u_return_date');
+      			g_form.showFieldMsg('u_return_date', 'Select Return Date in future than Start Date', 'error');
+		    }
+	  }
+}


### PR DESCRIPTION
This piece of code runs in an OnChange catalog client script for the field 'u_return_date' and validates the return date(u_return_date) in a ServiceNow Catalog item form to ensure:

1. A start date(u_start_date) is entered before setting a return date(u_return_date).
2. The return date is within 6 months after the start date.
3. Return date is not the start date or before that.

Let’s say with an example:

  u_start_date = 2025-10-01
  You enter u_return_date = 2026-04-15
  
  Steps:
  a)Difference = 196 days → More than 180 days
  b)Result: u_return_date is cleared and error shown: “Select Return Date within 6 months from Start Date”