### PR TITLE
Enforce SLA Rules on Change Requests with Scheduled Job Trigger

### DIFF
--- a/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/README.md
+++ b/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/README.md
@@ -1,0 +1,5 @@
+If a Change Request hasn't been moved to "Assess" state within 48 hours of submission,
+automatically send a reminder and log escalation task.
+This is a hybrid of a Business Rule + Scheduled Job (or Flow).
+This code sets up an automated escalation process for change requests in ServiceNow. When a new change request is created, it schedules a job to run after 48 hours using a `sys_trigger`. 
+If the change is still in the "New" state at that time, the Script Include sends a notification event and creates an escalation task assigned to the Change Management group. This ensures timely review and prevents unattended change requests.

--- a/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/ScriptInclude.js
+++ b/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/ScriptInclude.js
@@ -1,0 +1,22 @@
+var ChangeEscalationHelper = Class.create();
+ChangeEscalationHelper.prototype = {
+    initialize: function() {},
+
+    checkAndEscalate: function(changeId) {
+        var gr = new GlideRecord('change_request');
+        if (gr.get(changeId) && gr.state == '1') { // Assuming '1' = New
+            // Notify change manager
+            gs.eventQueue('change.escalate', gr, gs.getUserID(), '');
+            
+            // Log an escalation task
+            var task = new GlideRecord('task');
+            task.initialize();
+            task.short_description = "Escalation: Change not assessed in 48 hours";
+            task.parent = gr.sys_id;
+            task.assignment_group.setDisplayValue('Change Management');
+            task.insert();
+        }
+    },
+
+    type: 'ChangeEscalationHelper'
+};

--- a/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/businessRule.js
+++ b/Server-Side Components/Script Includes/Enforce SLA Rules on Change Requests with Scheduled Job Trigger/businessRule.js
@@ -1,0 +1,13 @@
+(function executeRule(current, gsn, gs) {
+
+    var timer = new GlideRecord('sys_trigger');
+    timer.initialize();
+    timer.name = "Change Escalation for: " + current.number;
+    timer.script = "new global.ChangeEscalationHelper().checkAndEscalate('" + current.sys_id + "');";
+    
+    var triggerTime = new GlideDateTime();
+    triggerTime.addSeconds(60 * 60 * 48); // 48 hours
+    timer.next_action = triggerTime;
+    timer.insert();
+
+})(current, gsn, gs);


### PR DESCRIPTION
If a Change Request hasn't been moved to "Assess" state within 48 hours of submission,
automatically send a reminder and log escalation task.
This is a hybrid of a Business Rule + Scheduled Job (or Flow).
This code sets up an automated escalation process for change requests in ServiceNow. When a new change request is created, it schedules a job to run after 48 hours using a `sys_trigger`. 
If the change is still in the "New" state at that time, the Script Include sends a notification event and creates an escalation task assigned to the Change Management group. This ensures timely review and prevents unattended change requests.
