### PR TITLE
Automatically Reopen Incidents Closed Prematurely

### DIFF
--- a/Server-Side Components/Business Rules/Automatically Reopen Incidents Closed Prematurely/README.md
+++ b/Server-Side Components/Business Rules/Automatically Reopen Incidents Closed Prematurely/README.md
@@ -1,0 +1,6 @@
+If a user reopens a closed incident within 5 minutes of closure (e.g., because the issue wasn't actually resolved), automatically reopen it, log the reason, and notify the assigned user.
+This code detects when an incident is reopened within 5 minutes of being closed. It compares the previous and current state of the record, and if it was previously Closed (state = 7) and is now Active, it calculates the time since closure. If the reopening happened within 5 minutes, it:
+Triggers an event incident.reopened_quickly for notifications or logging.
+Adds a work note explaining the automatic flag.
+Sets a custom flag field u_reopened_flag to true for tracking.
+This is useful for identifying and tracking incidents that are quickly reopened, possibly indicating incomplete resolution.

--- a/Server-Side Components/Business Rules/Automatically Reopen Incidents Closed Prematurely/code.js
+++ b/Server-Side Components/Business Rules/Automatically Reopen Incidents Closed Prematurely/code.js
@@ -1,0 +1,19 @@
+(function executeRule(current, previous /*null when async*/) {
+
+    var wasClosed = previous.state == 7; // Closed
+    var isNowActive = current.state != 7;
+
+    var closureTime = new GlideDateTime(previous.sys_updated_on);
+    var now = new GlideDateTime();
+    var minutesSinceClosure = GlideDateTime.subtract(now, closureTime).getNumericValue() / (1000 * 60);
+
+    if (wasClosed && isNowActive && minutesSinceClosure < 5) {
+        gs.eventQueue('incident.reopened_quickly', current, current.assigned_to, gs.getUserID());
+
+        current.work_notes = 'Reopened automatically — user reopened within 5 minutes of closure.';
+
+        // Optionally flag the incident
+        current.u_reopened_flag = true;
+    }
+
+})(current, previous);


### PR DESCRIPTION
If a user reopens a closed incident within 5 minutes of closure (e.g., because the issue wasn't actually resolved), automatically reopen it, log the reason, and notify the assigned user.
This code detects when an incident is reopened within 5 minutes of being closed. It compares the previous and current state of the record, and if it was previously Closed (state = 7) and is now Active, it calculates the time since closure. If the reopening happened within 5 minutes, it:
Triggers an event incident.reopened_quickly for notifications or logging.
Adds a work note explaining the automatic flag.
Sets a custom flag field u_reopened_flag to true for tracking.
This is useful for identifying and tracking incidents that are quickly reopened, possibly indicating incomplete resolution.