### PR TITLE
better README for Bulk Change of Incident Priority Based on Category

### DIFF
--- a/Server-Side Components/Background Scripts/ Bulk Change of Incident Priority Based on Category/README.md
+++ b/Server-Side Components/Background Scripts/ Bulk Change of Incident Priority Based on Category/README.md
@@ -1,1 +1,19 @@
-The code helps to automates the bulk update of incident priorities based on predefined category mappings. 
+# Bulk Change of Incident Priority Based on Category
+
+A background script that updates incident priorities for active incidents based on predefined category-to-priority mappings.
+
+## Usage
+
+1. Navigate to **System Definition → Scripts - Background**
+2. Copy and paste the script content
+3. Modify the `priorityMapping` object with your category-to-priority rules
+4. Click "Run script"
+
+## What It Does
+
+The script:
+1. Defines a mapping between incident categories and priority levels (e.g., 'Network': 1)
+2. Queries all active incidents
+3. Checks each incident's category against the mapping
+4. Updates the incident priority if a match is found
+5. Logs each updated incident number and new priority


### PR DESCRIPTION
# PR Description: 
I **only** updated the README.mb file linked to the  Priority Based on Category.js file.
This new README.md explains more about what the actual .js file does as well as how to use.
The .js code itself doesn't have any comments to explain, so this change seemed helpful and appropriate.

# Pull Request Checklist

## Overview
- [x] Put an x inside of the square brackets to check each item.
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes and the description has been filled in above.
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
