### PR TITLE
Enhance README with usage and functionality details

### DIFF
--- a/Server-Side Components/Background Scripts/Clone User with Roles and Groups/README.md
+++ b/Server-Side Components/Background Scripts/Clone User with Roles and Groups/README.md
@@ -1,2 +1,29 @@
 # Clone User with Roles and Groups
-I have created a script in ServiceNow to replicate a user's profile. This script not only duplicates the user's data but also replicates the roles and groups assigned to that user.
+
+A background script that clones an existing user's profile including all their roles and group memberships to a new user account.
+
+## Usage
+
+1. Navigate to **System Definition → Scripts - Background**
+2. Copy and paste the script content
+3. Update the function call at the bottom with the source and target user IDs:
+   ```javascript
+   cloneUser('source.username', 'new.username');
+   ```
+4. Click "Run script"
+
+## What It Does
+
+The script:
+1. Creates a new user record with the specified username
+2. Copies all field values from the source user to the new user (except fields already set)
+3. Clones all directly assigned roles (excludes inherited roles)
+4. Clones all group memberships
+5. Returns the sys_id of the newly created user
+
+## Use Cases
+
+- Onboarding new team members with similar access needs
+- Creating test users with specific role/group combinations
+- Setting up backup user accounts with identical permissions
+- Standardizing user setup based on role templates


### PR DESCRIPTION
# PR Description: 
I only updated the README.mb file linked to the CloneUser.js file.
This new README.md explains more about what the actual .js file does as well as how to use.
The .js code itself doesn't have much comments to explain, so this change seemed helpful and appropriate.

# Pull Request Checklist

## Overview
- [x] Put an x inside of the square brackets to check each item.
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes and the description has been filled in above.
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
