### PR TITLE
improved read me to activeGroupsWithoutMembers

### DIFF
--- a/Server-Side Components/Background Scripts/Fetch Active Groups list without members/README.md
+++ b/Server-Side Components/Background Scripts/Fetch Active Groups list without members/README.md
@@ -1,2 +1,16 @@
-Sample code to clean up the Groups with no members.
-This code help to get the Active groups list  with no members
+A background script that identifies and returns all active groups in ServiceNow that have no members assigned to them.
+
+## What It Does
+
+The script:
+1. Queries all active groups in the `sys_user_group` table
+2. For each group, checks the `sys_user_grmember` table for member count
+3. Uses GlideAggregate to efficiently count members per group
+4. Collects group names (or sys_ids) that have zero members
+5. Outputs the complete list of empty groups to the system log
+
+## Configuration Options
+
+- **Group names vs IDs**: Uncomment line 21 to collect group sys_ids instead of names
+- **Limit results**: Uncomment line 6 to limit the query to 1500 groups for large instances
+- **Additional filtering**: Modify the encoded query on line 3 to add specific group criteria


### PR DESCRIPTION
# PR Description: 
I only updated the README.mb file linked to the activeGroupsWithoutMembers.js file.
This new README.md explains more about what the actual .js file does as well as how to use.
The .js code itself doesn't have many comments to explain, so this change seemed helpful and appropriate.

# Pull Request Checklist

## Overview
- [x] Put an x inside of the square brackets to check each item.
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes and the description has been filled in above.
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
