### PR TITLE
IncidentCount updated ReadME

### DIFF
--- a/Server-Side Components/Background Scripts/Get incident count based on priority/README.md
+++ b/Server-Side Components/Background Scripts/Get incident count based on priority/README.md
@@ -1,1 +1,26 @@
-//To get the incident count based on priority.
+A background script that generates a comprehensive report showing the total number of incidents grouped by priority level in your ServiceNow instance.
+
+## What It Does
+
+The script:
+1. Creates a GlideAggregate query on the incident table
+2. Groups incidents by their priority field
+3. Counts the total number of incidents for each priority level
+4. Handles cases where priority is not set (displays as "No Priority Set")
+5. Outputs a formatted report showing priority names and their corresponding counts
+
+## Sample Output
+
+```
+Priority: 1 - Critical | Count: 15
+Priority: 2 - High | Count: 47
+Priority: 3 - Moderate | Count: 123
+Priority: 4 - Low | Count: 89
+No Priority Set | Count: 3
+```
+
+## Configuration Options
+
+- **Date filtering**: Add `.addQuery('opened_at', 'DATEPART', 'Today@javascript:gs.daysAgoStart(0)@javascript:gs.daysAgoEnd(0)')` to get today's incidents only
+- **State filtering**: Add `.addQuery('state', '!=', 7)` to exclude closed incidents
+- **Assignment filtering**: Add `.addQuery('assignment_group', 'group_sys_id')` to focus on specific teams


### PR DESCRIPTION
# PR Description: 
I only updated the README.mb file linked to the IncidentCount.js file.
This new README.md explains more about what the actual .js file does.
The .js code itself doesn't have any comments to explain, so this change seemed helpful and appropriate.

# Pull Request Checklist

## Overview
- [x] Put an x inside of the square brackets to check each item.
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes and the description has been filled in above.
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
