### PR TITLE
improved read me for GetRecordsFromMultipleTables

### DIFF
--- a/Server-Side Components/Background Scripts/GetRecordsFromMultipleTables/README.md
+++ b/Server-Side Components/Background Scripts/GetRecordsFromMultipleTables/README.md
@@ -1,1 +1,29 @@
-Creating a background script to print the total count of all tables with a specific filter condition
+A background script that retrieves record counts from multiple ServiceNow tables with date filtering, providing a comprehensive data audit report.
+
+## What It Does
+
+The script:
+1. Defines an array of table names to query (60+ tables by default)
+2. Iterates through each table using `forEach()` to process them systematically
+3. Uses `GlideAggregate` with COUNT aggregate for efficient record counting
+4. Applies a date filter to count records updated before a specific date
+5. Handles errors gracefully with try-catch blocks for invalid table names
+6. Outputs results in a formatted table structure with pipe separators
+
+
+## Sample Output
+
+```
+| Table |    Records 
+| customer_account |    1,245 records
+| cmn_location |    87 records
+| customer_contact |    3,456 records
+| cmdb_ci |    12,789 records
+We've got an error for table: invalid_table_name
+```
+
+## Configuration Options
+
+- **Date filtering**: Modify `sys_updated_on<=javascript:gs.dateGenerate('YYYY-MM-DD','HH:mm:ss')` to change the cutoff date
+- **Custom table list**: Replace the `tablesList` array with your specific tables of interest
+- **Additional filters**: Add more encoded query conditions like `active=true` or specific field criteria


### PR DESCRIPTION
# PR Description: 
I only updated the README.mb file linked to the GetRecordsFromMultipleTables script file.
This new README.md explains more about what the actual .js file does as well as how to use.
The .js code itself doesn't have many comments to explain, so this change seemed helpful and appropriate.

# Pull Request Checklist

## Overview
- [x] Put an x inside of the square brackets to check each item.
- [x] I have read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] My pull request has a descriptive title that accurately reflects the changes and the description has been filled in above.
- [x] I've included only files relevant to the changes described in the PR title and description
- [x] I've created a new branch in my forked repository for this contribution

## Code Quality
- [x] My code is relevant to ServiceNow developers
- [x] My code snippets expand meaningfully on official ServiceNow documentation (if applicable)
- [x] I've disclosed use of ES2021 features (if applicable)
- [x] I've tested my code snippets in a ServiceNow environment (where possible)

## Repository Structure Compliance
- [x] I've placed my code snippet(s) in one of the required top-level categories:
  - `Core ServiceNow APIs/`
  - `Server-Side Components/`
  - `Client-Side Components/`
  - `Modern Development/`
  - `Integration/`
  - `Specialized Areas/`
- [x] I've used appropriate sub-categories within the top-level categories
- [x] Each code snippet has its own folder with a descriptive name

## Documentation
- [x] I've included a README.md file for each code snippet
- [x] The README.md includes:
  - Description of the code snippet functionality
  - Usage instructions or examples
  - Any prerequisites or dependencies
  - (Optional) Screenshots or diagrams if helpful

## Restrictions
- [x] My PR does not include XML exports of ServiceNow records
- [x] My PR does not contain sensitive information (passwords, API keys, tokens)
- [x] My PR does not include changes that fall outside the described scope
