### PR TITLE
feat: Add Business Rule snippet for close code validation

### DIFF
--- a/Server-Side Components/Business Rules/Prevent-Invalid-State-Change/README.md
+++ b/Server-Side Components/Business Rules/Prevent-Invalid-State-Change/README.md
@@ -1,0 +1,15 @@
+# Prevent Incident Closure Without a Close Code
+
+This snippet is for a **'before' Business Rule** that prevents a user from closing an incident if the 'Close Code' field is empty. It displays an error message and aborts the update.
+
+## How to Use
+
+1.  **Table:** `incident`
+2.  **When:** `before`
+3.  **Actions:** Check `update`
+4.  **Condition (Filter):**
+    * `State | changes to | Closed`
+    * *(Note: 'Closed' is often value 7, but check your instance)*
+5.  **Advanced Tab:**
+    * Check the `Advanced` box.
+    * Paste the code from `prevent_closure.js` into the script field.

--- a/Server-Side Components/Business Rules/Prevent-Invalid-State-Change/prevent_closure.js
+++ b/Server-Side Components/Business Rules/Prevent-Invalid-State-Change/prevent_closure.js
@@ -1,0 +1,14 @@
+(function executeRule(current, previous /*, gs, sup*/) {
+
+  // Check if the close_code field is empty or null
+  // You can add other fields to this check, e.g., || gs.nil(current.close_notes)
+  if (gs.nil(current.close_code)) {
+
+      // Display an error message at the top of the form
+      gs.addErrorMessage('A Close Code is required before closing an incident.');
+
+      // Stop the database action (update) from happening
+      current.setAbortAction(true);
+  }
+
+})(current, previous);


### PR DESCRIPTION
Hello! This PR contributes a new, common code snippet for a server-side validation.

Description This snippet adds a 'before' Business Rule designed for the incident table. Its purpose is to prevent a record from being saved in the 'Closed' state if the 'Close Code' field is empty, which is a very common business requirement.

Functionality

Triggers on a before update, when the State changes to Closed.

Checks if the current.close_code field is empty.

If it's empty, it displays a friendly error message to the user using gs.addErrorMessage().

Stops the database update using current.setAbortAction(true).

Contribution Checklist

[x] Snippet placed in the correct category: Server-Side Components/Business Rules/Prevent-Invalid-State-Change/

[x] Includes a README.md inside the snippet folder with clear setup instructions.

[x] Follows all CONTRIBUTING.md guidelines.

Thank you for the opportunity to contribute! Happy Hacktoberfest! 🎃