### PR TITLE
Add Execution Time Tracker Script Include snippet

### DIFF
--- a/Server-Side Components/Script Includes/Execution Time Tracker/README.md
+++ b/Server-Side Components/Script Includes/Execution Time Tracker/README.md
@@ -1,0 +1,20 @@
+
+# Script Execution Time Tracker
+
+This snippet helps developers measure how long their server-side scripts take to run in ServiceNow.
+Useful for performance optimization and debugging slow background scripts or Script Includes.
+
+## Example Use Case
+- Measure performance of a GlideRecord query or function execution.
+- Log the execution time to the system logs.
+
+## How It Works
+The script uses timestamps before and after execution to measure elapsed time.
+
+## Usage
+Wrap your logic between `start` and `stop`, or use the Script Include:
+
+```javascript
+var timer = new ExecutionTimeTracker();
+// ... your code ...
+timer.stop('My Script');

--- a/Server-Side Components/Script Includes/Execution Time Tracker/execution_time_tracker.js
+++ b/Server-Side Components/Script Includes/Execution Time Tracker/execution_time_tracker.js
@@ -1,0 +1,15 @@
+var ExecutionTimeTracker = Class.create();
+ExecutionTimeTracker.prototype = {
+    initialize: function() {
+        this.startTime = new Date().getTime();
+    },
+
+    stop: function(label) {
+        var endTime = new Date().getTime();
+        var duration = endTime - this.startTime;
+        gs.info((label || 'Execution') + ' completed in ' + duration + ' ms');
+        return duration;
+    },
+
+    type: 'ExecutionTimeTracker'
+};


### PR DESCRIPTION
### Overview
Added a reusable Script Include snippet to measure and log the execution time of server-side scripts.

### Details
- **Folder:** Server-Side Components/Script Includes/Execution Time Tracker
- **Files:**
  - execution_time_tracker.js
  - README.md
- Helps developers analyze and optimize script performance in ServiceNow.

### Example Usage
```javascript
var timer = new ExecutionTimeTracker();
// ... code logic ...
timer.stop('My Script');

